### PR TITLE
Update build-definitions references to new org

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
@@ -2,7 +2,7 @@
 
 When you build your pipeline, you might want to add tasks that require **secrets** in order to access external resources.
 
-NOTE: One such task is the link:https://github.com/redhat-appstudio/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
+NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
 
 If you want to create an application using source code from GitLab, you need to add a GitLab access token to {ProductName} __before__ you create an application. For details, see <<Creating secrets for GitLab-sourced apps>> below.
 

--- a/docs/modules/ROOT/pages/how-tos/configuring/hermetic-builds.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/hermetic-builds.adoc
@@ -19,7 +19,7 @@ spec:
 ====
 * Hermetic builds disable network access, so a build with dependencies outside of its Git repository--including supported languages--might fail. To prevent this, or to pull in dependencies from a package manager for one of the xref:how-tos/configuring/prefetching-dependencies.adoc#supported-languages[supported languages], follow the instructions in link:https://konflux-ci.dev/docs/how-tos/configuring/prefetching-dependencies/[Prefetching the package manager dependencies for the hermetic build].
 +
-Similarly, with a link:https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml[Buildah] task for a non-Java application, when you set the `*hermetic*` parameter to `true`, you’re isolating the build from the network, which restricts it to building only from dependencies listed in your Git repository. 
+Similarly, with a link:https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml[Buildah] task for a non-Java application, when you set the `*hermetic*` parameter to `true`, you’re isolating the build from the network, which restricts it to building only from dependencies listed in your Git repository. 
 
 * Do not add these parameters to the link:https://github.com/burrsutter/partner-catalog-stage/blob/e2ebb05ba8b4e842010710898d555ed3ba687329/.tekton/partner-catalog-stage-wgxd-pull-request.yaml#L87[`**pipelineSpec.params**`] section, as it should always display the default values for hermetic builds.
 ====


### PR DESCRIPTION
STONEBLD-2339

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
