### PR TITLE
Adding the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,6 @@
-# Konflux-CI Documentation Contributing Guide
+# Konflux-CI documentation contributing guide
 
-AsciiDoc is a plain text documentation syntax, also known as a mark-up
-language, for text files. AsciiDoc is rendered as HTML automatically by
-web browsers, so the files can be viewed as formatted text via the GitLab
-repository URL.
-
-## Development
+## Contributing
 
 For active maintenance/development of the documentation, developers
 should create a
@@ -18,7 +13,14 @@ specific branches in their forked repositories, but merge request should
 always target the default branch of the
 [Konflux repository](https://github.com/konflux-ci/docs).
 
-### Rendering Individual Pages
+## Working with AsciiDoc
+
+The Konflux documentation is developed in AsciiDoc format. AsciiDoc is a plain text documentation syntax, also known as a mark-up
+language, for text files. AsciiDoc is rendered as HTML automatically by
+web browsers, so the files can be viewed as formatted text via the GitLab
+repository URL.
+
+### Rendering individual pages
 
 To render individual AsciiDoc pages for review,
 use the `asciidoctor` software to generate HTML files.
@@ -45,7 +47,7 @@ for information on enabling AsciiDoc rendering.
 > below to render the entire site for a final check of any changes to the
 > documentation.
 
-### Rendering the Entire Site
+### Rendering the entire site
 
 To locally render the entire site, navigate to the root of the repository
 and run:
@@ -71,7 +73,23 @@ python -m pip install watchdog[watchmedo]
 watchmedo auto-restart --patterns="*.adoc" --recursive npm run dev
 ```
 
-## AsciiDoc Mark-Up Language References
+### Converting Markdown to AsciiDoc
+
+If you prefer to work with Markdown, you can convert your Markdown files into AsciiDoc using any conversion tool, for example Pandoc:
+
+1. Install [Pandoc](https://pandoc.org/installing.html)
+
+2. Convert a file by running the following command:
+
+```bash
+pandoc [file name].md -f markdown -t asciidoc [file name].adoc
+```
+
+The `-f` option specifies the input format, and the `-t` option specifies the output format. For more options, see [General options](https://pandoc.org/chunkedhtml-demo/3.1-general-options.html) for the `pandoc` command.
+
+3. Render the resulting AsciiDoc file using the Integrated Development Environment (IDE) of your choice, the `asciidoctor` text processor, or any other option.
+
+### AsciiDoc mark-up language references
 
 The [AsciiDoc Writer's Guide](https://asciidoctor.org/docs/asciidoc-writers-guide/)
 "provides a gentle introduction to AsciiDoc".

--- a/docs/modules/ROOT/pages/contribute/index.adoc
+++ b/docs/modules/ROOT/pages/contribute/index.adoc
@@ -1,1 +1,34 @@
 = Contribute to {ProductName}
+
+We appreciate any edits that you suggest! You can choose to edit documentation in your browser or locally on your machine.
+
+== Contributing in a browser 
+
+To contribute to this documentation, select *Edit this Page* in the banner on any page. This action takes you to the link:https://github.com/konflux-ci/docs[source docs on GitHub] and opens a web editor, where you can propose specific changes.
+
+NOTE: When suggesting changes, use the AsciiDoc syntax because that's what we use when writing the Konflux-CI documentation.
+
+When you finish editing in GitHub, select *Create a new branch for this commit and start a pull request*. Then, name your pull request and select *Propose changes*.
+
+== Editing locally 
+
+You can edit documentation on your machine and suggest the changes using GitHub. Commit your proposed updates to a specific branch in your forked repository and open a pull request against the default branch in the link:https://github.com/konflux-ci/docs[upstream Konflux-CI/docs repository]. For more details, see the link:https://github.com/konflux-ci/docs/blob/main/CONTRIBUTING.md[Konflux-CI docs contributing guide] on GitHub.
+
+.Converting Markdown to AsciiDoc
+
+If you prefer to work with Markdown, you need to convert your Markdown files into AsciiDoc using any conversion tool, for example Pandoc:
+
+. Install link:https://pandoc.org/installing.html[Pandoc]
+
+. Convert a file by running the following command:
+
++
+[source,bash]
+----
+pandoc [file name].md -f markdown -t asciidoc [file name].adoc
+----
+
++
+The `-f` option specifies the input format, and the `-t` option specifies the output format. For more options, see link:https://pandoc.org/chunkedhtml-demo/3.1-general-options.html[General options] for the `pandoc` command.
+
+. Render the resulting AsciiDoc file using the Integrated Development Environment (IDE) of your choice, the `asciidoctor` text processor, or any other option. For details, see the link:https://github.com/konflux-ci/docs/blob/main/CONTRIBUTING.md[Konflux-CI docs contributing guide].

--- a/docs/modules/ROOT/pages/contribute/index.adoc
+++ b/docs/modules/ROOT/pages/contribute/index.adoc
@@ -1,34 +1,18 @@
 = Contribute to {ProductName}
 
-We appreciate any edits that you suggest! You can choose to edit documentation in your browser or locally on your machine.
+To contribute to this documentation:
 
-== Contributing in a browser 
+. Select *Edit this Page* in the banner on any page. This action takes you to the link:https://github.com/konflux-ci/docs[source docs on GitHub] and opens a web editor, where you can propose specific changes.
 
-To contribute to this documentation, select *Edit this Page* in the banner on any page. This action takes you to the link:https://github.com/konflux-ci/docs[source docs on GitHub] and opens a web editor, where you can propose specific changes.
-
++
 NOTE: When suggesting changes, use the AsciiDoc syntax because that's what we use when writing the Konflux-CI documentation.
 
-When you finish editing in GitHub, select *Create a new branch for this commit and start a pull request*. Then, name your pull request and select *Propose changes*.
+. When you finish editing in GitHub, select *Create a new branch for this commit and start a pull request*.
 
-== Editing locally 
+. Name your pull request and select *Propose changes*.
 
-You can edit documentation on your machine and suggest the changes using GitHub. Commit your proposed updates to a specific branch in your forked repository and open a pull request against the default branch in the link:https://github.com/konflux-ci/docs[upstream Konflux-CI/docs repository]. For more details, see the link:https://github.com/konflux-ci/docs/blob/main/CONTRIBUTING.md[Konflux-CI docs contributing guide] on GitHub.
+. For a review and merge, tag Andrew McNamara (@arewm) or any other contributor from the **Contributors** section on the link:https://github.com/konflux-ci/docs[Konflux-CI docs repository page]. If a redhatter, you can ask for a review in `#konflux-docs` in Slack.
 
-.Converting Markdown to AsciiDoc
+NOTE: You can also choose to fork the link:https://github.com/konflux-ci/docs[Konflux-CI/docs repository] on GitHub and edit documentation locally on your machine. For contribution guidelines and AsciiDoc help, see the link:https://github.com/konflux-ci/docs/blob/main/CONTRIBUTING.md[Konflux-CI docs contributing guide].
 
-If you prefer to work with Markdown, you need to convert your Markdown files into AsciiDoc using any conversion tool, for example Pandoc:
-
-. Install link:https://pandoc.org/installing.html[Pandoc]
-
-. Convert a file by running the following command:
-
-+
-[source,bash]
-----
-pandoc [file name].md -f markdown -t asciidoc [file name].adoc
-----
-
-+
-The `-f` option specifies the input format, and the `-t` option specifies the output format. For more options, see link:https://pandoc.org/chunkedhtml-demo/3.1-general-options.html[General options] for the `pandoc` command.
-
-. Render the resulting AsciiDoc file using the Integrated Development Environment (IDE) of your choice, the `asciidoctor` text processor, or any other option. For details, see the link:https://github.com/konflux-ci/docs/blob/main/CONTRIBUTING.md[Konflux-CI docs contributing guide].
+We appreciate any edits that you suggest!

--- a/docs/modules/ROOT/pages/contribute/index.adoc
+++ b/docs/modules/ROOT/pages/contribute/index.adoc
@@ -11,8 +11,6 @@ NOTE: When suggesting changes, use the AsciiDoc syntax because that's what we us
 
 . Name your pull request and select *Propose changes*.
 
-. For a review and merge, tag Andrew McNamara (@arewm) or any other contributor from the **Contributors** section on the link:https://github.com/konflux-ci/docs[Konflux-CI docs repository page]. If a redhatter, you can ask for a review in `#konflux-docs` in Slack.
-
 NOTE: You can also choose to fork the link:https://github.com/konflux-ci/docs[Konflux-CI/docs repository] on GitHub and edit documentation locally on your machine. For contribution guidelines and AsciiDoc help, see the link:https://github.com/konflux-ci/docs/blob/main/CONTRIBUTING.md[Konflux-CI docs contributing guide].
 
 We appreciate any edits that you suggest!


### PR DESCRIPTION
Reworked and extended the [AppStudio Contribute page](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/contribute/).
Included the Mardown > AsciiDoc conversion option as requested in a JIRA issue.