### PR TITLE
docs(STONEINTG-766): add description of build-time tasks by test team

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/testing/build/index.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/build/index.adoc
@@ -1,1 +1,48 @@
 = Build-time tests
+
+This document covers the build-time tests that {ProductName} runs as part of its component build pipeline. These build-time tests automatically check all application images to inform you if they're up-to-date, correctly formatted, and protected from security vulnerabilities.
+
+NOTE: These tests are non-blocking and do not prevent the pipeline from proceeding if issues are found.
+
+The component build pipeline for {ProductName} include various types of build-time tests, conducted using link:https://tekton.dev/docs/pipelines/tasks/#overview[Tekton tasks]. For validating container information, the pipeline employs https://www.conftest.dev/[Conftest]. 
+
+The table below outlines the default build-time tests:
+
+.Deprecated image checks
+|===
+|Test name |Description |Failure message
+
+|image_repository_deprecated |Deprecated images are no longer maintained, leading to unresolved security vulnerabilities. | The container image must not be built from a repository  marked as 'Deprecated' in COMET
+|===
+
+.Unsigned RPM check
+|===
+|Test name |Description |Failure message
+
+|image_unsigned_rpms |Packages signed with Red Hat's secure signing server adheres to stringent policies and procedures. |Alerts the user for any unsigned RPMs. Found following unsigned rpms(nvra):
+|===
+
+.Source code check
+|===
+|Test name |Description |Failure message
+
+|sast-snyk-check |Scans and analyze source code or compiled versions of code to help find security flaws. | <tbd>
+|===
+
+You can disable the default build-time tests by setting the `skip-checks` parameter to `true`
+
+[source,yaml]
+----
+- description: Skip checks against built image
+  name: skip-checks
+  type: string
+  default: "false"
+----
+ 
+
+[role="_additional-resources"]
+== Additional resources
+
+* For information about enabling Snyk task, see xref:how-tos/testing/build/snyk.adoc[Enabling a Snyk task].
+
+* For additional build-time tests, see link:https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/[Customizing the build pipeline].

--- a/docs/modules/ROOT/pages/how-tos/testing/build/index.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/build/index.adoc
@@ -22,11 +22,15 @@ The table below outlines the default build-time tests:
 |image_unsigned_rpms |Packages signed with Red Hat's secure signing server adheres to stringent policies and procedures. |Alerts the user for any unsigned RPMs. Found following unsigned rpms(nvra):
 |===
 
-.Source code check
+.Security checks
 |===
 |Test name |Description |Failure message
 
-|sast-snyk-check |Scans and analyze source code or compiled versions of code to help find security flaws. | <tbd>
+|clair-scan |Scans container images for vulnerabilities using Clair, by comparing the components of container image against Clair's vulnerability databases. | Found packages with critical vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs.
+
+|clamav-scan |Scans the content of container images for viruses, malware, and other malicious content using ClamAV antivirus scanner. | A malware has been found.
+
+|sast-snyk-check |Scans and analyze source code or compiled versions of code to help find security flaws using Snyk Code. | For details, check Tekton task log.
 |===
 
 You can disable the default build-time tests by setting the `skip-checks` parameter to `true`
@@ -38,7 +42,6 @@ You can disable the default build-time tests by setting the `skip-checks` parame
   type: string
   default: "false"
 ----
- 
 
 [role="_additional-resources"]
 == Additional resources

--- a/docs/modules/ROOT/pages/how-tos/testing/build/snyk.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/build/snyk.adoc
@@ -1,6 +1,54 @@
-= Enabling Snyk
+= Enabling a Snyk task
 
-While a Snky test is available to run a build time in the default pipelines, additional configuration is needed to enable the test. This is an example of a build-time test that requires the configuration of a custom secret to be able to run.
+The Snyk test is available to run at build time in the default pipelines, but it requires additional configuration to enable. This procedural example illustrates a build-time test that requires the configuration of a custom secret.
 
-+
-NOTE:  We may want to consider generalizing this topic.
+The `sast-snyk-check` task uses the Snyk Code tool to perform static application security testing (SAST). 
+Specifically, the Snyk check scans an application's source code for potential security vulnerabilities, 
+including SQL injection, cross-site scripting (XSS), and code injection attack vulnerabilities.
+
+NOTE: You can run a Snyk task only if you have a Snyk token configured in a namespace secret. Ensure that the name of your secret is included in the *snyk-secret* pipeline parameter.
+
+.Procedure
+
+. Register for a Snyk account or log in at https://app.snyk.io/.
+. Get a Snyk token.
+
+.. In the lower left of the home page, click your name, then select *Account settings*.
+
+.. From the Account Settings page, select *General*, which is the default, then *Auth Token*.
+
+.. Under the *Auth Token* section, click *Click to View* to see the *KEY* value of the automatically generated token.
+
+. Enable Snyk Code.
+
+.. From the left panel, go to *Settings* > *Snyk Code*, then scroll to the *Enable Snyk Code* section.
+
+.. Toggle *Disabled* to *Enabled*.
+
+.. Click *Save* changes.
+
+. Add your new secret to your workspace.
+
+.. Log in to {ProductName} Overview page.
+
+.. From the left menu, click *Secrets*.
+
+.. Click *Add secret*.
+
+.. The *Add secret* page displays options for your new secret. Specify the following:
+
+... For *Secret for*, select *Build*.
+
+... From the *Secret type* drop-down menu, choose *Key/value secret*.
+
+... From the *Secret name* drop-down menu, select *snyk-secret*.
+
+... Paste your Snyk token into the *Upload the file with value for your key or paste its contents* field.
+... Click *Add secret* to save it.
+
+You've enabled the Snyk task for your build pipeline.
+
+[role="_additional-resources"]
+== Additional resources
+
+For more information about Snyk, see link:https://snyk.io/product/snyk-code/[the Snyk website].


### PR DESCRIPTION
Needs to be rebased after https://github.com/konflux-ci/docs/pull/38 is merged.