### PR TITLE
nudges: components referenced across applications

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/configuring/component-nudges.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/component-nudges.adoc
@@ -1,6 +1,6 @@
 = Defining component relationships
 
-When a workspace includes multiple components, their repositories might contain references to image builds of another component. For instance, an application might include multiple child components that, using a Dockerfile `FROM` clause, reference the image build of a common parent. Or, a component might reference a image builds from another application altogether. OpenShift operators, for example, often have references to several components across applications.
+When a workspace includes multiple components, their repositories might contain references to image builds of another component. For instance, an application might include multiple child components that, using a Dockerfile `FROM` clause, reference the image build of a common parent. Or, a component might reference image builds from another application altogether. OpenShift operators, for example, often have references to several components across applications.
 
 In such instances, whenever you build a new image of the common parent component, you need to update the references to it. Specifically, you need to copy and paste the pullspec and image digest of that new image to your other source repositories. This process is tedious and error-prone.
 

--- a/docs/modules/ROOT/pages/how-tos/configuring/component-nudges.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/component-nudges.adoc
@@ -22,7 +22,7 @@ To define the relationships between components in a workspace, complete the foll
 
 [NOTE]
 ====
-Applications with only one component do not have the option to define relationships in the UI. To achieve the same result for single-component applications, you can define the relationship in the CLI.
+Currently, applications with only one component do not have the option to define relationships in the UI. To achieve the same result for single-component applications, you can define the relationship in the CLI.
 ====
 
 

--- a/docs/modules/ROOT/pages/how-tos/configuring/component-nudges.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/component-nudges.adoc
@@ -1,6 +1,6 @@
 = Defining component relationships
 
-When an application includes multiple components, their repositories might contain references to image builds of another component. For instance, an application might include multiple child components that, using a Dockerfile `FROM` clause, reference the image build of a common parent.
+When a workspace includes multiple components, their repositories might contain references to image builds of another component. For instance, an application might include multiple child components that, using a Dockerfile `FROM` clause, reference the image build of a common parent. Or, a component might reference a image builds from another application altogether. OpenShift operators, for example, often have references to several components across applications.
 
 In such instances, whenever you build a new image of the common parent component, you need to update the references to it. Specifically, you need to copy and paste the pullspec and image digest of that new image to your other source repositories. This process is tedious and error-prone.
 
@@ -11,17 +11,23 @@ However, if you build an application with {ProductName} and make references betw
 By default, {ProductName} only looks for image digest references in Dockerfiles, Containerfiles, and YAML files. However, you can xref:./customizing-the-build.adoc[customize your build pipeline] to adjust that list of files with an annotation. This functionality is only available for push builds, so add the following annotation under `annotations` in your component's `/.tekton/<component-name>-push.yaml` file:
 `build.appstudio.openshift.io/build-nudge-files: "<comma-separated list of link:https://docs.renovatebot.com/string-pattern-matching/[regex or glob patterns]>"`
 
-The existing list of patterns is: ".\*Dockerfile.*, .\*.yaml, .*Containerfile.*"  
+The existing list of patterns is: ".\*Dockerfile.*, .\*.yaml, .*Containerfile.*"
 ====
 
 == In the UI
 
 .Procedure
 
-To define the relationships between components in an application, complete the following steps in the {ProductName} UI:
+To define the relationships between components in a workspace, complete the following steps in the {ProductName} UI:
 
-. Navigate to your application. 
-. On any tab, use the *Actions* drop-down menu to select *Define component relationships*. 
+[NOTE]
+====
+Applications with only one component do not have the option to define relationships in the UI. To achieve the same result for single-component applications, you can define the relationship in the CLI.
+====
+
+
+. Navigate to your application.
+. On any tab, use the *Actions* drop-down menu to select *Define component relationships*.
 .. Alternatively, go to the *Components* tab and select the *Define component relationships*.
 . In the *Component relationships* window, select one component from the *Select a component* drop-down menu.
 . Select *Nudges* or *Is nudged by*, depending on the relationship you wish to define.
@@ -29,7 +35,7 @@ To define the relationships between components in an application, complete the f
 +
 [NOTE]
 ====
-Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if Component B contains a reference, by image digest, to a build of Component A. After successful push builds of Component A, nudging updates the image digest that Component B references. 
+Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if Component B contains a reference, by image digest, to a build of Component A. After successful push builds of Component A, nudging updates the image digest that Component B references.
 ====
 
 . Use the remaining drop-down menu to choose which other components belong to this relationship.
@@ -39,9 +45,9 @@ Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if 
 .Verification
 
 To verify the new relationship in the UI:
-. Go to the *Components* tab for your application. 
+. Go to the *Components* tab for your application.
 . Select a component that belongs to the relationship you defined.
-. Scroll to the end of the page and select *Show related components*. 
+. Scroll to the end of the page and select *Show related components*.
 
 Alternatively, in the git repo for the component that nudges, push a commit. When the build for that component completes, you should see a new pull request appear for the component that is nudged. This new pull request contains the image digest for the new build of its parent image.
 
@@ -61,12 +67,12 @@ Prerequisites:
 
 . In your CLI, xref:/getting-started/cli.adoc[login] to {ProductName}.
 . List your components, and identify the names of the components you want to relate to each other.
-+ 
++
 `oc get components`
 +
 [NOTE]
 ====
-Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if Component B contains a reference by image digest to a build of Component A. After successful push builds of Component A, nudging updates the image digest that Component B references. 
+Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if Component B contains a reference by image digest to a build of Component A. After successful push builds of Component A, nudging updates the image digest that Component B references.
 ====
 . Patch the components to establish the nudging relationship.
 +
@@ -77,8 +83,8 @@ Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if 
 
 .Verification
 
-* Get the component custom resource (CR) definition for the components that nudges. The definition should include a line that says `build-nudges-ref:`, and beneath that, the name of the component that is nudged.   
-+ 
+* Get the component custom resource (CR) definition for the components that nudges. The definition should include a line that says `build-nudges-ref:`, and beneath that, the name of the component that is nudged.
++
 `oc get components/<name of component that nudges> -o yaml --kubeconfig=<path to kubeconfig> | less`
 * Push a commit to the component that nudges. When the build completes, you should see a new pull request appear for the component that is nudged. This new pull request contains the image digest for the new build of the parent image.
 


### PR DESCRIPTION
It is possible for components to nudge or be nudged by components in another application altogether. The existing documentation did not make this clear. This change is an attempt to clarify that.