### PR TITLE
Fix title for maintaining-references-before-release.adoc

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/releasing/maintaining-references-before-release.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/releasing/maintaining-references-before-release.adoc
@@ -1,4 +1,4 @@
-== Maintaining valid image references before a release
+= Maintaining valid image references before a release
 
 When images are xref:/advanced-how-tos/releasing/index.adoc[released] they will usually be copied to another image repository. If any image build-time image references are used within component (for example, xref:/advanced-how-tos/building-olm.adoc[OLM bundles]) any references will be invalid after releasing. To surmount this, {ProductName} enables your xref:/how-tos/configuring/component-nudges.adoc[component nudges] to be updated with image references which will be valid after release.
 

--- a/docs/modules/ROOT/pages/advanced-how-tos/releasing/maintaining-references-before-release.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/releasing/maintaining-references-before-release.adoc
@@ -2,6 +2,8 @@
 
 When images are xref:/advanced-how-tos/releasing/index.adoc[released] they will usually be copied to another image repository. If any image build-time image references are used within component (for example, xref:/advanced-how-tos/building-olm.adoc[OLM bundles]) any references will be invalid after releasing. To surmount this, {ProductName} enables your xref:/how-tos/configuring/component-nudges.adoc[component nudges] to be updated with image references which will be valid after release.
 
+== Configuring nudges for the released image repository targets
+
 .Procedure
 
 . Configure your xref:/advanced-how-tos/releasing/create-release-plan-admission.adoc[release plan admission] for a release pipeline which will copy the images to a new repository.


### PR DESCRIPTION
The first line was too low of a header so the rendering did not properly capture the page title resulting in `Untitled`.