### PR TITLE
fix note syntax

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/creating.adoc
+++ b/docs/modules/ROOT/pages/how-tos/creating.adoc
@@ -116,7 +116,6 @@ spec:
 
 After a pipeline completes with a built artifact, you may want to test the resulting image to ensure that it works properly. The `IMAGE_URL` Tekton result (discoverable from the UI or CLI) should be set to the pullspec for the image.
 
-+
 NOTE: {ProductName} automatically deletes images built for PR pipelines five days after building them.
 
 === With the UI


### PR DESCRIPTION
Note on the `Creating applications and components` does not look correct.

<img src="https://github.com/user-attachments/assets/913f36a8-fc83-45d7-85a6-119c7bb782e0" width="500">

Change the note so it looks like it should (please ignore the different IDE theme)

<img src="https://github.com/user-attachments/assets/57a54991-76d7-432d-b33d-fa3d92581fe2" width="500">
