### PR TITLE
feat(STONEINTG-954): Document the integration test selection logic

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/_nav.adoc
+++ b/docs/modules/ROOT/pages/how-tos/_nav.adoc
@@ -24,6 +24,7 @@
 **** xref:how-tos/testing/integration/debugging.adoc[Debugging an integration test]
 **** xref:how-tos/testing/integration/rerunning.adoc[Rerunning an integration test]
 **** xref:how-tos/testing/integration/override-snapshots.adoc[Creating an override snapshot]
+**** xref:how-tos/testing/integration/choosing-contexts.adoc[Choosing when to run certain Integration Tests]
 ** xref:how-tos/metadata/index.adoc[Inspecting provenance and attestations]
 *** xref:how-tos/metadata/sboms.adoc[Inspecting SBOMs]
 *** xref:how-tos/metadata/attestations.adoc[Inspecting artifact attestations]

--- a/docs/modules/ROOT/pages/how-tos/testing/integration/choosing-contexts.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/choosing-contexts.adoc
@@ -1,29 +1,30 @@
 = Choosing when to run certain Integration Tests
 
-Integration test scenarios can be configured to run in only certain cases (contexts).
-The supported contexts are listed below:
+Integration test scenarios can be configured to run in only certain cases (referred to as contexts in further text).
+Examples include running the integration test pipelines only in case of Pull Requests, or running them only for builds of specific components.
+The full list of supported contexts is:
 
 * “application”  - runs the integration test in all cases - this is the default state
-* “component” - runs the integration tests only in case of single component builds - this is the most common use case
-* "group” - runs the integration test for a Snapshot that was created for a PR group
-* "override” - runs the integration test for an `override`  Snapshot
-** See more in xref:how-tos/testing/integration/override-snapshots.adoc[Creating an override snapshot]
-* “component_COMPONENT” - runs the integration test for a specific component update
+* “component” - runs the integration tests only in case of component builds
+** This context is run for builds of all components, but not for special cases like manually created Snapshots
+* “component_COMPONENT” - runs the integration test only for a build of a specific component
 ** For a component  `sample-component`, this context would need to be `component_sample-component`
 * "pull_request” - runs the integration test in case of the Snapshot being created for a `pull request` event
 * “push” - runs the integration test in case of the Snapshot being created for a `push` event
+* "override” - runs the integration test for an `override`  Snapshot
+** See more in xref:how-tos/testing/integration/override-snapshots.adoc[Creating an override snapshot]
 
 +
-NOTE: Setting more than one context in the list will run the IntegrationTestScenario for both contexts (logical OR).
+NOTE: Setting more than one context in the list will run the IntegrationTestScenario for all included contexts.
 
 .Prerequisites
 - You have CLI access to the specific OpenShift cluster. For information on obtaining CLI access, refer link:https://konflux-ci.dev/docs/getting-started/cli/[Getting started with the CLI].
 
 .Procedure
 
-. Identify the IntegrationTestScenario that you want to run only in certain cases.
+. Choose the IntegrationTestScenario that you want to run only in certain cases.
 
-. Edit the IntegrationTestScenario using kubectl.
+. Edit the chosen IntegrationTestScenario using kubectl.
 
 +
 [source]
@@ -36,7 +37,7 @@ $ kubectl edit integrationtestscenario [integrationtestscenario name]
 Example integrationTestScenario configuration with the pull_request context:
 
 +
-[source]
+[source,yaml]
 ----
 apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario

--- a/docs/modules/ROOT/pages/how-tos/testing/integration/choosing-contexts.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/choosing-contexts.adoc
@@ -1,0 +1,65 @@
+= Choosing when to run certain Integration Tests
+
+Integration test scenarios can be configured to run in only certain cases (contexts).
+The supported contexts are listed below:
+
+* “application”  - runs the integration test in all cases - this is the default state
+* “component” - runs the integration tests only in case of single component builds - this is the most common use case
+* "group” - runs the integration test for a Snapshot that was created for a PR group
+* "override” - runs the integration test for an `override`  Snapshot
+** See more in xref:how-tos/testing/integration/override-snapshots.adoc[Creating an override snapshot]
+* “component_COMPONENT” - runs the integration test for a specific component update
+** For a component  `sample-component`, this context would need to be `component_sample-component`
+* "pull_request” - runs the integration test in case of the Snapshot being created for a `pull request` event
+* “push” - runs the integration test in case of the Snapshot being created for a `push` event
+
++
+NOTE: Setting more than one context in the list will run the IntegrationTestScenario for both contexts (logical OR).
+
+.Prerequisites
+- You have CLI access to the specific OpenShift cluster. For information on obtaining CLI access, refer link:https://konflux-ci.dev/docs/getting-started/cli/[Getting started with the CLI].
+
+.Procedure
+
+. Identify the IntegrationTestScenario that you want to run only in certain cases.
+
+. Edit the IntegrationTestScenario using kubectl.
+
++
+[source]
+----
+$ kubectl edit integrationtestscenario [integrationtestscenario name]
+----
+
+. Modify the `contexts` field by setting the list of contexts you wish the IntegrationTestScenario.
++
+Example integrationTestScenario configuration with the pull_request context:
+
++
+[source]
+----
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: example-pass
+  namespace: default
+spec:
+  application: application-sample
+  contexts:
+    - description: PR testing
+      name: pull_request
+  resolverRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/konflux-ci/integration-examples
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/integration_pipeline_pass.yaml
+----
+
+.Verification
+
+. To verify the configuration, run a component build in the desired context (e.g. as part of a Pull Request) and
+verify if the integration test pipeline was executed according to your expectations.

--- a/docs/modules/ROOT/pages/how-tos/testing/integration/creating.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/creating.adoc
@@ -1,12 +1,12 @@
 = Creating a custom integration test
 
-In {ProductName}, you can create your own integration tests to run on all components of a given application before they are deployed. 
+In {ProductName}, you can create your own integration tests to run on all components of a given application before they are deployed.
 
 .Procedure
 
 To create any custom test, complete the following steps:
 
-. In your preferred IDE, create a Tekton pipeline in a `.yaml` file. 
+. In your preferred IDE, create a Tekton pipeline in a `.yaml` file.
 
 . Within that pipeline, create tasks, which define the actual steps of the test that {ProductName} executes against images before deploying them.
 
@@ -24,7 +24,7 @@ To create a custom test that checks that your app serves the text “Hello world
 Example pipeline file:
 
 +
-[source]
+[source,yaml]
 ----
 kind: Pipeline
 apiVersion: tekton.dev/v1beta1
@@ -45,7 +45,7 @@ spec:
 Example task declaration:
 
 +
-[source]
+[source,yaml]
 ----
 tasks:
   - name: task-1
@@ -79,7 +79,7 @@ tasks:
 
 ----
 
-. Save the `.yaml` file. 
+. Save the `.yaml` file.
 
 .. If you haven’t already, commit this file to a GitHub repository that {ProductName} can access.
 
@@ -87,7 +87,7 @@ tasks:
 Complete example file:
 
 +
-[source]
+[source,yaml]
 ----
 kind: Pipeline
 apiVersion: tekton.dev/v1beta1
@@ -157,10 +157,56 @@ Labels:
 
 * *`appstudio.openshift.io/snapshot`*: contains the name of the snapshot.
 
-* *`test.appstudio.openshift.io/optional`*: contains the optional flag, which specifies whether or not components must pass the integration test before release. 
+* *`test.appstudio.openshift.io/optional`*: contains the optional flag, which specifies whether or not components must pass the integration test before release.
 
-* *`test.appstudio.openshift.io/scenario`*: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`). 
+* *`test.appstudio.openshift.io/scenario`*: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`).
 
+NOTE: It is also possible to set custom labels or annotations in the build pipelineRun, and those will be copied over
+to all integration pipelineRuns associated with that build. The labels/annotations have to have the
+`custom.appstudio.openshift.io` prefix in order to be copied in this manner.
+
+.Utilizing the labels and annotations within the integration pipeline run
+
+It is possible to use the injected metadata within the integration PipelineRun itself in order to influence the testing behavior.
+This can be done by exposing the pipelineRun labels as environment variables within a Task and then referencing them within the Task logic.
+
+Example of extracting the component name and finding its image within the SNAPSHOT parameter's JSON data:
+
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-metadata
+spec:
+  params:
+    - name: SNAPSHOT
+      description: The JSON string of the Snapshot under test
+  steps:
+    - name: find-component-image
+      image: quay.io/redhat-appstudio/konflux-test:stable
+      workingDir: /workspace
+      env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: COMPONENT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+      script: |
+        #!/bin/sh
+
+        # Extract the component container image from the SNAPSHOT JSON data
+        COMPONENT_CONTAINER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.components[] | select(.name == $component_name) | .containerImage' <<< "${SNAPSHOT}")
+
+        # Log the extracted variable
+        echo "  COMPONENT_CONTAINER_IMAGE: ${COMPONENT_CONTAINER_IMAGE}"
+----
+
+NOTE: For more examples of available labels and how they can be used within the integration tests, consult the
+link:https://github.com/konflux-ci/integration-examples/blob/main/tasks/test_metadata.yaml[example test-metadata task] as well as the
+link:https://github.com/konflux-ci/integration-examples/blob/main/pipelines/integration_resolver_pipeline_pass_metadata.yaml[example integration pipeline]
+which uses the information from that task's results to influence its workflow.
 
 .Verification
 


### PR DESCRIPTION
* Add the Choosing when to run certain Integration Tests page
* Document the example test-metadata task usage within the
  integration testing pipelines
* Document the ability for users to provide custom annotations/labels
  to their PaC definitions and access them in their integration tests

Signed-off-by: dirgim <kpavic@redhat.com>