### PR TITLE
Replace redhat-appstudio-tekton-catalog references

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/managing-compliance-with-ec/index.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/managing-compliance-with-ec/index.adoc
@@ -10,6 +10,6 @@ If you ever need to restore the default EC integration test to an application, o
 * To produce a signed link:https://in-toto.io/in-toto/[in-toto] attestation of the build pipeline, go to link:https://tekton.dev/docs/chains/[Tekton Chains].
 * For information on the source code for the Tekton pipelines defined in the bundle, see the link:https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract.yaml[build-definitions] and
 link:https://github.com/enterprise-contract/ec-cli/blob/main/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml[ec-cli] repositories.
-* To use a specific version of the pipeline bundle instead of the devel tag, you can select one of the link:https://quay.io/repository/redhat-appstudio-tekton-catalog/pipeline-enterprise-contract?tab=tags[pinned tags].
+* To use a specific version of the pipeline bundle instead of the devel tag, you can select one of the link:https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-enterprise-contract?tab=tags[pinned tags].
 * For information on components in Enterprise Contract, see the link:https://enterprisecontract.dev/docs/ec/main/index.html#_components[Components].
 * For information on the Enterprise Contract policies designed for {ProductName}, see the link:https://enterprisecontract.dev/docs/ec-policies/index.html[Enterprise Contract Policies].

--- a/docs/modules/ROOT/pages/how-tos/configuring/custom-tags.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/custom-tags.adoc
@@ -52,7 +52,7 @@ You can also specify additional custom tags by using *ADDITIONAL_TAGS* array par
     - name: name
       value: apply-tags
     - name: bundle
-      value: quay.io/redhat-appstudio-tekton-catalog/task-apply-tags:0.1
+      value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1
     - name: kind
       value: task
     resolver: bundles


### PR DESCRIPTION
These are deprecated, the new location is konflux-ci/tekton-catalog.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
