### PR TITLE
docs: fix typo on release plan example

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/releasing/create-release-plan.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/releasing/create-release-plan.adoc
@@ -35,7 +35,7 @@ spec:
  application: <application-name> <.>
  data: <key> <.>
  pipelineRef: <pipeline-ref> <.>
- serviceAccont: <service-account> <.>
+ serviceAccount: <service-account> <.>
  target: managed-workspace <.>
 ----
 


### PR DESCRIPTION
change "serviceAccont" to "serviceAccount".