### PR TITLE
Remove app name from default ImageRepository name

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/managing-multiple-versions.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/managing-multiple-versions.adoc
@@ -72,7 +72,7 @@ spec:
     metadata:
       annotations:
         build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
-        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/konflux-ci/multi-version-konflux-sample/pull/1","configuration-time":"Wed, 07 Aug 2024 08:59:18 UTC"},"message":"done"}'      
+        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/konflux-ci/multi-version-konflux-sample/pull/1","configuration-time":"Wed, 07 Aug 2024 08:59:18 UTC"},"message":"done"}'
       name: multi-version-konflux-sample-{{.versionName}}
     spec:
       application: "multi-version-konflux-sample-{{.versionName}}"
@@ -93,7 +93,7 @@ spec:
         appstudio.redhat.com/component: multi-version-konflux-sample-{{.versionName}}
     spec:
       image:
-        name: konflux-samples-tenant/multi-version-konflux-sample-{{.versionName}}/multi-version-konflux-sample-{{.versionName}}
+        name: konflux-samples-tenant/multi-version-konflux-sample-{{.versionName}}
         visibility: public
       notifications:
         - config:

--- a/docs/modules/ROOT/pages/how-tos/creating.adoc
+++ b/docs/modules/ROOT/pages/how-tos/creating.adoc
@@ -99,10 +99,10 @@ metadata:
   namespace: <namespace>
   labels:
     appstudio.redhat.com/application: <application-name>
-    appstudio.redhat.com/component: <component-name> 
+    appstudio.redhat.com/component: <component-name>
 spec:
   image:
-    name: <namespace>/<application-name>/<component-name>
+    name: <namespace>/<component-name>
     visibility: public <.>
 --
 


### PR DESCRIPTION
In a recent commit [1], we changed the default ImageRepository name from '{namespace}/{application}/{component}' to '{namespace}/{component}'. The goal was to shorten image names while maintaining uniqueness (component names are unique within a namespace).

Update the templates accordingly to align with the default behavior.

[1]: https://github.com/konflux-ci/image-controller/commit/d9c695b343f8056d37b06a398f489bb4aa36d004