### PR TITLE
Remove unused parameters from custom integration test example.

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/testing/integration/creating.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/creating.adoc
@@ -99,14 +99,6 @@ spec:
       name: SNAPSHOT
       default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
       type: string
-    - description: 'Namespace where the application is running'
-      name: NAMESPACE
-      default: "default"
-      type: string
-    - description: 'Expected output'
-      name: EXPECTED_OUTPUT
-      default: "Hello World!"
-      type: string
   tasks:
     - name: task-1
       description: Placeholder task that prints the Snapshot and outputs standard TEST_OUTPUT


### PR DESCRIPTION
I assume these parameters are not relevant for the example because they are not covered in the rest of the document.

@arewm ptal.