### PR TITLE
update no space left troubleshoot docs

### DIFF
--- a/docs/modules/ROOT/pages/troubleshooting/index.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting/index.adoc
@@ -27,11 +27,14 @@ spec:
     - name: workspace
       volumeClaimTemplate:
         spec:
+          accessModes:
+            - ReadWriteOnce
           resources:
             requests:
               storage: 1Gi  # increase accordingly
 ----
 
+For other accessModes, refer to the kubernetes documentation link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes[here].
 
 == Pipeline Run Times Out
 


### PR DESCRIPTION
Without the accessModes, saw the following error:

```
Failed to create PVC for PipelineRun ocp-art-tenant/ose-4-18-ose-cli-artifacts-gp4hk correctly: PVC creation error: failed to create PVC pvc-75394cfb72: PersistentVolumeClaim "pvc-75394cfb72" is invalid: spec.accessModes: Required value: at least 1 access mode is required
```