### PR TITLE
Add note on how to get access to quay on release

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/releasing/create-release.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/releasing/create-release.adoc
@@ -56,3 +56,11 @@ $ kubectl apply -f Release.yaml -n dev
 . Click on the *Releases* tab
 . See the recent releases that have been created for the application.
 . You can find a link to the release pipeline run by clicking on the name of the release that you created.
+
+== Finding your release in the registry
+
+In order to access the target registry for the release, you will likely need to update RBAC configuration for the quay organization.
+
+https://gitlab.cee.redhat.com/exd/quay/quay-access-management
+
+Open a merge request against the `quay-access-management` repository to add yourself or your team to the relevant organization.


### PR DESCRIPTION
Multiple threads in the konflux-users channel trying to figure out why they can't see the `redhat-services-prod` org. 

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1729768334150819

The context here will change and the text should likely update with:
https://issues.redhat.com/browse/RELEASE-570