### PR TITLE
fix: error: unable to decode "STDIN": json: cannot unmarshal bool into Go struct field ObjectMeta.metadata.annotations of type string

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/creating.adoc
+++ b/docs/modules/ROOT/pages/how-tos/creating.adoc
@@ -96,7 +96,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ImageRepository <.>
 metadata:
   annotations:
-    image-controller.appstudio.redhat.com/update-component-image: true
+    image-controller.appstudio.redhat.com/update-component-image: 'true'
   name: imagerepository-for-<application-name>-<component-name>
   namespace: <namespace>
   labels:


### PR DESCRIPTION
Without this change, I was getting this error when creating that entity:

    error: unable to decode "STDIN": json: cannot unmarshal bool into Go struct field ObjectMeta.metadata.annotations of type string