### PR TITLE
Drop the common prefix of ImageRepository names

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/managing-multiple-versions.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/managing-multiple-versions.adoc
@@ -87,7 +87,7 @@ spec:
   - apiVersion: appstudio.redhat.com/v1alpha1
     kind: ImageRepository
     metadata:
-      name: imagerepository-for-multi-version-konflux-sample-{{.versionName}}
+      name: multi-version-konflux-sample-{{.versionName}}
       labels:
         appstudio.redhat.com/application: multi-version-konflux-sample-{{.versionName}}
         appstudio.redhat.com/component: multi-version-konflux-sample-{{.versionName}}

--- a/docs/modules/ROOT/pages/how-tos/creating.adoc
+++ b/docs/modules/ROOT/pages/how-tos/creating.adoc
@@ -97,7 +97,7 @@ kind: ImageRepository <.>
 metadata:
   annotations:
     image-controller.appstudio.redhat.com/update-component-image: 'true'
-  name: imagerepository-for-<application-name>-<component-name>
+  name: <component-name>
   namespace: <namespace>
   labels:
     appstudio.redhat.com/application: <application-name>


### PR DESCRIPTION
In short: the common prefix of ImageRepository names is too long, which triggers https://issues.redhat.com/browse/SRVKP-6798

Drop the prefix.