### PR TITLE
change pipeline to tenantPipeline

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/releasing/tenant-release-pipelines.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/releasing/tenant-release-pipelines.adoc
@@ -43,7 +43,7 @@ spec:
        - name: demo-component-2
          repository: registry/destination-image-repository-2
          tags: [latest]
- pipeline:
+ tenantPipeline:
    pipelineRef: <.>
      resolver: git
      params:


### PR DESCRIPTION
- release-service now expects `tenantPipeline` instead of `pipeline`, see https://github.com/konflux-ci/release-service/blob/e091a3b077f7b1743c17869a043b8fd8856c6112/api/v1alpha1/releaseplan_types.go#L49
- using `pipeline` results in an `unknown field error` which leads to user confusion
- change `pipeline` to `tenantPipeline` to reflect the release-service change