### PR TITLE
Add Vale linter to CI

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,21 @@
+name: Linters
+on:
+  - pull_request
+jobs:
+  vale:
+    name: vale
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Asciidoctor
+        run: sudo apt-get install -y asciidoctor
+      - name: Vale Linter
+        uses: errata-ai/vale-action@reviewdog
+        with:
+          vale_flags: "--minAlertLevel=error"
+          fail_on_error: true
+        env:
+          # Required, set by GitHub actions automatically:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ public/
 # Netlify deploy output from preview workflow
 deploy.json
 .DS_Store
+
+# Vale styles
+.vale/styles/*
+!.vale/styles/config

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,15 @@
+StylesPath = .vale/styles
+
+MinAlertLevel = warning
+
+IgnoredScopes = code, tt, img, url, a, body.id
+
+SkippedScopes = script, style, pre, figure, code, tt, blockquote, listingblock, literalblock
+
+Packages = RedHat
+
+Vocab = konflux
+
+[*.adoc]
+
+BasedOnStyles = RedHat

--- a/.vale/styles/config/vocabularies/konflux/accept.txt
+++ b/.vale/styles/config/vocabularies/konflux/accept.txt
@@ -1,0 +1,5 @@
+lockfile
+prefetch
+Snyk
+Konflux
+kubectl


### PR DESCRIPTION
This patch introduces [Vale](https://vale.sh/docs) as a writing style linter, and configures it using Red Hat's [styles](https://redhat-documentation.github.io/vale-at-red-hat/docs/main/user-guide/introduction/).

It also sets up a corresponding Github Action to run Vale during the CI. If any of the lines introduced by the PR causes an error level linting message, the CI will fail.