### PR TITLE
chore: generalize github references

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/testing/integration/adding.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/adding.adoc
@@ -45,4 +45,4 @@ When the new build is finished:
 
 . xref:./editing.adoc[Edit the integration test] if it is not properly configured.
 
-The test results will also be available from the PR in Github or Gitlab.  In Github the test results can be viewed in the *Checks* tab.  In Gitlab the test results will show up in the *Pipelines* tab.  In both cases comments will be created once the integration tests finish running showing the results of the most recent test run
+The test results will also be available from the PR in GitHub or the MR in GitLab. In GitHub, the test results can be viewed in the *Checks* tab. In GitLab, the test results will show up in the *Pipelines* tab. In both cases, comments will be created once the integration tests finish running, showing the results of the most recent test run.

--- a/docs/modules/ROOT/pages/how-tos/testing/integration/adding.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/adding.adoc
@@ -16,7 +16,7 @@ Complete the following steps in the {ProductName} console:
 
 . In the *Integration test name* field, enter a name of your choosing.
 
-. In the *GitHub URL* field, enter the URL of the GitHub repository that contains the test you want to use.
+. In the *git url* field, enter the URL of the git repository that contains the test you want to use.
 
 +
 NOTE: If you do not already have a custom test that you want to add, we tell you how to xref:./creating.adoc[create a custom integration test] in the next section.
@@ -33,7 +33,7 @@ NOTE: By default, all integration test scenarios are mandatory and must pass. A 
 
 .Verification
 
-To start building a new component, either open a new pull request (PR) that targets the tracked branch of the component in the GitHub repository, or comment '/retest' on an existing PR.
+To start building a new component, either open a new pull request (PR) that targets the tracked branch of the component in the git repository, or comment '/retest' on an existing PR.
 
 When the new build is finished:
 
@@ -45,3 +45,4 @@ When the new build is finished:
 
 . xref:./editing.adoc[Edit the integration test] if it is not properly configured.
 
+The test results will also be available from the PR in Github or Gitlab.  In Github the test results can be viewed in the *Checks* tab.  In Gitlab the test results will show up in the *Pipelines* tab.  In both cases comments will be created once the integration tests finish running showing the results of the most recent test run


### PR DESCRIPTION
Prior to this change the documentation for adding integration tests was github-specific.  This change makes the documentation more general to avoid confusion for users adding components and integration tests from Gitlab.