### PR TITLE
fix: minor typo in CLI documentation

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/cli.adoc
+++ b/docs/modules/ROOT/pages/getting-started/cli.adoc
@@ -83,7 +83,7 @@ users:
 +
 [source]
 --
-export $KUBECONFIG=<path to your kubeconfig file>
+export KUBECONFIG=<path to your kubeconfig file>
 --
 +
 .. Or, overwrite the file located at `~/.kube/config` with your `kubeconfig` file.


### PR DESCRIPTION
Removed `$` from environment variable setup