### PR TITLE
Change the name of the snyk secret to create

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
@@ -12,7 +12,7 @@ Secrets can be categorized depending on when they need to be added.
 
 Sometimes to run the tasks properly, you may need to pass secrets to these tasks. Consult the documentation for these tasks to understand the proper specification of the secrets required, for example the required keys/values.
 
-NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
+NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `snyk-secret` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
 
 .Procedure 
 


### PR DESCRIPTION
The default secret name for the task is `snyk-secret`: https://github.com/konflux-ci/build-definitions/blob/9f209df8c12e8b321e63b77b5c91cb1523080a59/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml#L49-L51

Therefore, in order to make it work out of the box, that should probably be the name that we suggest for users to configure.