### PR TITLE
docs(RELEASE-1320): update tenant pipeline example pipelineRef

### DIFF
--- a/docs/modules/ROOT/pages/advanced-how-tos/releasing/tenant-release-pipelines.adoc
+++ b/docs/modules/ROOT/pages/advanced-how-tos/releasing/tenant-release-pipelines.adoc
@@ -48,11 +48,11 @@ spec:
      resolver: git
      params:
        - name: url
-         value: "https://github.com/konflux-ci/release-service-catalog.git"
+         value: "https://github.com/<your-github-user>/<your-pipeline-repo>.git"
        - name: revision
-         value: production
+         value: main
        - name: pathInRepo
-         value: "pipelines/push-to-external-registry/push-to-external-registry.yaml"
+         value: "<path-to-your-pipeline>"
    serviceAccountName: appstudio-pipeline <.>
 ----
 


### PR DESCRIPTION
The pipelineRef in the tenant pipeline never really made much sense. It suggested using a managed pipeline, which would not work (and many users made this mistake). This updates the example to something that should be more obviously an example and not a real pipeline.

We also moved the pipeline definitions in release-service-catalog, so the old reference won't even exist going forward. That is another reason to change it.

If a working tenant pipeline is created, we can update the docs to use that as the example.