### PR TITLE
fix(Konflux 5917):  add an example how user can use a secret in pipeline 

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
@@ -1,89 +1,167 @@
-# Using Secrets in Konflux Pipelines
+= Creating secrets for your builds
 
-## Introduction
-Secrets are used to securely store sensitive information like API tokens, passwords, and other credentials in your CI/CD pipelines.
+When you build your pipeline, you might want to add tasks that require **secrets** in order to access external resources.
 
-## Types of Secrets
-- **Task Input Secrets**: Used for tasks that require specific secrets to function properly.
-- **Registry Pull Secrets**: Used to pull container images from private registries.
-- **Source Control Secrets**: Used to access source control platforms like GitLab or GitHub.
+Secrets can be categorized depending on when they need to be added.
 
-## Creating Secrets
-### Task Input Secrets
-To create a key/value secret in Konflux:
-1. Navigate to the **Secrets** page.
-2. Click **Add secret**.
-3. Select **Key/value secret**.
-4. Enter a unique name for your secret.
-5. Add the key/value pairs as required.
+. Before a component is added. If a secret is needed to access the source control platform like xref:/how-tos/configuring/creating-secrets.adoc#creating-source-control-secrets[GitLab], you must create a secret before you create the component.
+. Before a build succeeds. Some artifact build tasks need specific secrets to be able to pull all of the content to include in the final artifact. For example, you can add secrets for xref:/how-tos/configuring/creating-secrets.adoc#creating-registry-pull-secrets[container registries] after you create the component but they must be provided before a successful build can occur.
+. After a component has been onboarded. These secrets are often used in tasks. The tasks included in the {ProductName} pipelines will not fail if a secret is not created properly. Instead, the task will just not run the code like with xref:/how-tos/configuring/creating-secrets.adoc#creating-task-input-secrets[snyk].
 
-### Registry Pull Secrets
-To create an image pull secret:
-1. Obtain the username and password for the container registry.
-2. Navigate to the **Secrets** page.
-3. Click **Add secret**.
-4. Select **Image pull secret**.
-5. Enter the registry server address, username, and password.
+== Creating task input secrets
 
-### Source Control Secrets
-To create a secret for accessing GitLab repositories:
-1. Create a Project Access Token in GitLab.
-2. Use the following YAML to create the secret:
-   ```yaml
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: pipelines-as-code-secret
-     namespace: <YOUR NAMESPACE>
-     labels:
-       appstudio.redhat.com/credentials: scm
-       appstudio.redhat.com/scm.host: gitlab.com
-   type: kubernetes.io/basic-auth
-   stringData:
-     password: <PROJECT ACCESS TOKEN>
-Using Secrets in Pipeline YAML
-Referencing Secrets in Tasks
-To reference a secret in a task, use the valueFrom field with secretKeyRef:
+Sometimes to run the tasks properly, you may need to pass secrets to these tasks. Consult the documentation for these tasks to understand the proper specification of the secrets required, for example the required keys/values.
 
-yaml
-Copy
-apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
+
+.Procedure 
+
+. In {ProductName}, from the left navigation menu, select **Secrets**.
+. From the **Secrets** page, click **Add secret**.
+. For **Secret type**, select **Key/value secret**
+. For **Secret name**, enter a unique name for your secret.
+. Under **Key/value secret**, expand **Key/value 1**, then enter a key.
+. For **Upload the file with value for your key or paste its contents**, do one of the following:
+    * Click **Upload** to browse to, select, and upload the file that contains your key value.
+    * Drag the file that contains your key value into the space under **Upload**.
+    * Paste the contents of the file that contains your key value into the space under **Upload**.
+  Click **Clear** to remove the contents of the space under **Upload**.
+. Optional: Click **Add another key/value**.
+. Optional: Under **Labels**, add a label to tag or provide more context for your secret.
+. Click **Add secret**.
+
+== Creating registry pull secrets
+
+Some container builds may use parent images from registries that require authentication, for example, `registry.redhat.io`. Until these credentials have been configured, the builds will continue to fail due to the system being unable to pull the required images.
+
+.Procedure
+
+. Obtain the username and password login credentials for the container registry.
+    * For access to `registry.redhat.io`, you can create a registry service account at https://access.redhat.com/terms-based-registry/accounts.
+. In the correct {ProductName} workspace, go to **Secrets**. 
+. Click **Add secret**.  
+. For **Secret type**, select **Image pull secret**.
+. For **Authentication type**, select **Image registry credentials**.
+. For **Registry server address** enter the image registry (for example `registry.redhat.io`).
+. Enter the username for the registry in **Username**.
+. Enter the password for the registry in **Password**.
+. Click **Add secret**.
+
+
+[NOTE]
+====
+Performing this operation through the UI will link the secret to the `appstudio-pipeline`
+`serviceaccount` automatically. If you instead wanted to add manually the secret to the
+namespace (creating the `secret` directly on the tenant
+workspace), you'll need to have the secret linked manually.
+
+please review the xref:/troubleshooting/index.adoc#check-if-the-secret-is-linked-to-the-service-account[troubleshooting section]) for more info.
+====
+
+== Creating source control secrets
+
+When building content from GitHub, you will need to install an application for Pipelines as Code in your repository. For supported source control management platforms that do not have an application, however, access tokens will need to be added to your {ProductName} workspace before creating your component.
+
+.Prerequisites
+
+* You have completed the steps listed in the xref:/getting-started/cli.adoc[Getting started in the CLI] page.
+
+.Procedure (GitLab)
+
+. In GitLab click on Settings -> Access Tokens on the left menu of your repository. **NOTE:** if you don't see this option, you need someone with permissions to do so.
+. Then click on `Add new token`.
+. Select the following scopes: `api`, `read_repository`, and `write_repository`.
+. If your GitLab instance supports setting token roles, set the role to `Maintainer`.
+. Select **Create project access token**.
+. Add a token to your {ProductName} workspace by running the `kubectl create` command and creating a new YAML file with a secret:
+
++
+[source,bash]
+----
+kubectl create -f GL-secret.yaml
+----
+
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
 metadata:
-  name: sast-snyk-check
-spec:
-  taskRef:
-    name: sast-snyk-check
-  params:
-    - name: snyk_token
-      valueFrom:
-        secretKeyRef:
-          name: sast_snyk_task
-          key: snyk_token
-Best Practices
-Security: Always ensure that secrets are stored securely.
+  name: pipelines-as-code-secret
+  namespace: <YOUR NAMESPACE>
+  labels:
+    appstudio.redhat.com/credentials: scm
+    appstudio.redhat.com/scm.host: <source-control-management-host> # for example, gitlab.com
+type: kubernetes.io/basic-auth
+stringData:
+  password: <PROJECT ACCESS TOKEN>
+----
 
-Naming Conventions: Use consistent naming conventions for secrets.
++
+[NOTE]
+====
+Using the PAT authentication requires only the `password` key. The `username` should not be set. If you set both the `username` and `password` keys, the authentication type will be considered as `basic`, and a basic authentication client will be created using those credentials. This client might not work or can be considered as a deprecated login method by some Source Code Management (SCM) providers.
+====
 
-Access Control: Limit access to secrets to only those who need them.
+This secret will be used by the build service to perform builds with Pipeline-as-Code.
 
-Troubleshooting
-Common Issues
-Secrets not being recognized by tasks.
+This Project Access Tokens are scoped to a project, so you cannot use them to access resources from other projects. For more information regarding Project Access Tokens, see the Gitlab https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html[documentation].
 
-Incorrect secret names or keys.
+It is also possible to have secrets for per-repository or organization access. To do this, a `appstudio.redhat.com/scm.repository` annotation should be added to the secret. It may either specify the full repository path or the partial path with a wildcard. For example, to create a secret for all repositories in the `my-user` organization, create (or add) the following YAML file:
 
-Debugging Tips
-Check the secret name and key in the pipeline YAML.
 
-Verify that the secret exists in the correct namespace.
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: <YOUR NAMESPACE>
+  labels:
+    appstudio.redhat.com/credentials: scm
+    appstudio.redhat.com/scm.host: <source-control-management-host> # for example, gitlab.com
+  annotations:
+    appstudio.redhat.com/scm.repository: my-user/*
+type: kubernetes.io/basic-auth
+stringData:
+  password: <PROJECT ACCESS TOKEN>
+----
 
-Additional Resources
-Konflux GitHub repository
+For a specific repository, the following secret should be created:
 
-Tekton documentation
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: <YOUR NAMESPACE>
+  labels:
+    appstudio.redhat.com/credentials: scm
+    appstudio.redhat.com/scm.host: <source-control-management-host> # for example, gitlab.com
+  annotations:
+    appstudio.redhat.com/scm.repository: <repository-path> # for example, my-user/my-repo
+type: kubernetes.io/basic-auth
+stringData:
+  password: <PROJECT ACCESS TOKEN>
+----
 
-GitLab Project Access Tokens
+[NOTE]
+====
+* You can have multiple repositories listed under the `appstudio.redhat.com/scm.repository` annotation. Separate repository names with commas when listing them. The secret will be used for all repositories that match the specified paths.
 
-Conclusion
-Using secrets correctly in your pipelines is crucial for security and functionality. Follow best practices and refer to the documentation for more details.
+* You can also have multiple secrets with different labels and/or annotations. In order to work, at least the additional ones, need to be named with `pipeline-as-code-secret` as prefix (for example pipeline-as-code-secret-xxx).
+====
+
+[IMPORTANT]
+==== 
+* Secrets lookup mechanism is searching for the most specific secret first. The secret with a repository annotation will be used first if it matches the component repository path. In none found, then a lookup will try to find a secret with a wildcard, or just the host matching one.
+
+* If you upload a GitLab access token to a workspace, {ProductName} won’t use the global GitHub application when accessing GitHub repositories.
+====
+
+.Additional resources
+
+* For more information about GitLab access tokens, see link:https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html[Project access tokens].
+
+* To configure push secrets for your Build and Release pipelines, see link:https://github.com/konflux-ci/konflux-ci?tab=readme-ov-file#configuring-a-push-secret-for-the-build-pipeline[Configuring push secrets] in the Konflux GitHub repository.

--- a/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
@@ -30,6 +30,13 @@ NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/
 . Optional: Under **Labels**, add a label to tag or provide more context for your secret.
 . Click **Add secret**.
 
+=== Notable task input secrets
+
+* xref:/how-tos/configuring/activation-keys-subscription.adoc#adding-activation-keys-to-the-workspace[activation-key]
+* xref:/how-tos/configuring/prefetching-dependencies.adoc#creating-the-netrc-secret[netrc]
+* xref:/how-tos/testing/build/snyk.adoc[snyk-secret]
+* xref:/how-tos/testing/integration/third-parties/testing-farm.adoc[testing-farm-secret]
+
 == Creating registry pull secrets
 
 Some container builds may use parent images from registries that require authentication, for example, `registry.redhat.io`. Until these credentials have been configured, the builds will continue to fail due to the system being unable to pull the required images.
@@ -47,15 +54,56 @@ Some container builds may use parent images from registries that require authent
 . Enter the password for the registry in **Password**.
 . Click **Add secret**.
 
+=== Example of creating a quay.io secret
+
+. Login to {ProductName} console your workspace (https://console.redhat.com/application-pipeline/workspaces/<your workspace>/applications)
+. Click on `Secrets` on the left menu.
+. Click on `Add Secret`
+. Choose `Image pull secret` for `Secret type`
+. Enter `Secret name` , for example `my-quay-secret` 
+. Choose `Image registry credentials` in `Authentication type` field
+. Enter `quay.io` in `Registry server address`
+. Enter your Quay.io username in `Username`
+. Enter your Quay.io API token in `Password` field.
+. Click on `Add secret`
+. Email is optional
+
+
+Here is the YAML representation of the secret (for reference):
+
+[source,yaml]
+----
+apiVersion: v1
+data:
+.dockerconfigjson: <base64-encoded-credentials>
+kind: Secret
+metadata:
+name: my-quay-secret
+namespace: <your-workspace-tenant>
+type: kubernetes.io/dockerconfigjson
+----
+
 
 [NOTE]
 ====
-Performing this operation through the UI will link the secret to the `appstudio-pipeline`
-`serviceaccount` automatically. If you instead wanted to add manually the secret to the
-namespace (creating the `secret` directly on the tenant
-workspace), you'll need to have the secret linked manually.
+* **Automatic Secret Linking via UI**  
+  The {ProductName} UI automatically links image pull secrets to the `appstudio-pipeline` ServiceAccount.  
+  - No pipeline YAML changes are required.  
+  - Tasks like the buildah task will use this secret automatically when pulling images from `quay.io`. (https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml in volumes) 
 
-please review the xref:/troubleshooting/index.adoc#check-if-the-secret-is-linked-to-the-service-account[troubleshooting section]) for more info.
+* **Manual Secret Creation**  
+  . **Link Secret To SA** 
+    - If you create the secret manually (e.g., via `kubectl` or YAML), you must **manually link it** to the `appstudio-pipeline` ServiceAccount in your namespace.
+  . **Secrets Via Workspace** 
+    - Explicitly mount secrets as files using a workspace
+    - RBAC: Ensure the ServiceAccount has permission to access the secret (via Role/RoleBinding).
+
+  . **Secrets as Environment Variables** 
+    - Inject secrets into environment variables
+    - RBAC: The ServiceAccount must have `get` permission for the secret.
+
+* **Troubleshooting**  
+  For issues with secret linking, review the xref:/troubleshooting/index.adoc#check-if-the-secret-is-linked-to-the-service-account[troubleshooting section].
 ====
 
 == Creating source control secrets

--- a/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/creating-secrets.adoc
@@ -1,174 +1,89 @@
-= Creating secrets for your builds
+# Using Secrets in Konflux Pipelines
 
-When you build your pipeline, you might want to add tasks that require **secrets** in order to access external resources.
+## Introduction
+Secrets are used to securely store sensitive information like API tokens, passwords, and other credentials in your CI/CD pipelines.
 
-Secrets can be categorized depending on when they need to be added.
+## Types of Secrets
+- **Task Input Secrets**: Used for tasks that require specific secrets to function properly.
+- **Registry Pull Secrets**: Used to pull container images from private registries.
+- **Source Control Secrets**: Used to access source control platforms like GitLab or GitHub.
 
-. Before a component is added. If a secret is needed to access the source control platform like xref:/how-tos/configuring/creating-secrets.adoc#creating-source-control-secrets[GitLab], you must create a secret before you create the component.
-. Before a build succeeds. Some artifact build tasks need specific secrets to be able to pull all of the content to include in the final artifact. For example, you can add secrets for xref:/how-tos/configuring/creating-secrets.adoc#creating-registry-pull-secrets[container registries] after you create the component but they must be provided before a successful build can occur.
-. After a component has been onboarded. These secrets are often used in tasks. The tasks included in the {ProductName} pipelines will not fail if a secret is not created properly. Instead, the task will just not run the code like with xref:/how-tos/configuring/creating-secrets.adoc#creating-task-input-secrets[snyk].
+## Creating Secrets
+### Task Input Secrets
+To create a key/value secret in Konflux:
+1. Navigate to the **Secrets** page.
+2. Click **Add secret**.
+3. Select **Key/value secret**.
+4. Enter a unique name for your secret.
+5. Add the key/value pairs as required.
 
-== Creating task input secrets
+### Registry Pull Secrets
+To create an image pull secret:
+1. Obtain the username and password for the container registry.
+2. Navigate to the **Secrets** page.
+3. Click **Add secret**.
+4. Select **Image pull secret**.
+5. Enter the registry server address, username, and password.
 
-Sometimes to run the tasks properly, you may need to pass secrets to these tasks. Consult the documentation for these tasks to understand the proper specification of the secrets required, for example the required keys/values.
+### Source Control Secrets
+To create a secret for accessing GitLab repositories:
+1. Create a Project Access Token in GitLab.
+2. Use the following YAML to create the secret:
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: pipelines-as-code-secret
+     namespace: <YOUR NAMESPACE>
+     labels:
+       appstudio.redhat.com/credentials: scm
+       appstudio.redhat.com/scm.host: gitlab.com
+   type: kubernetes.io/basic-auth
+   stringData:
+     password: <PROJECT ACCESS TOKEN>
+Using Secrets in Pipeline YAML
+Referencing Secrets in Tasks
+To reference a secret in a task, use the valueFrom field with secretKeyRef:
 
-NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `snyk-secret` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
-
-.Procedure 
-
-. In {ProductName}, from the left navigation menu, select **Secrets**.
-. From the **Secrets** page, click **Add secret**.
-. For **Secret type**, select **Key/value secret**
-. For **Secret name**, enter a unique name for your secret.
-. Under **Key/value secret**, expand **Key/value 1**, then enter a key.
-. For **Upload the file with value for your key or paste its contents**, do one of the following:
-    * Click **Upload** to browse to, select, and upload the file that contains your key value.
-    * Drag the file that contains your key value into the space under **Upload**.
-    * Paste the contents of the file that contains your key value into the space under **Upload**.
-  Click **Clear** to remove the contents of the space under **Upload**.
-. Optional: Click **Add another key/value**.
-. Optional: Under **Labels**, add a label to tag or provide more context for your secret.
-. Click **Add secret**.
-
-=== Notable task input secrets
-
-* xref:/how-tos/configuring/activation-keys-subscription.adoc#adding-activation-keys-to-the-workspace[activation-key]
-* xref:/how-tos/configuring/prefetching-dependencies.adoc#creating-the-netrc-secret[netrc]
-* xref:/how-tos/testing/build/snyk.adoc[snyk-secret]
-* xref:/how-tos/testing/integration/third-parties/testing-farm.adoc[testing-farm-secret]
-
-== Creating registry pull secrets
-
-Some container builds may use parent images from registries that require authentication, for example, `registry.redhat.io`. Until these credentials have been configured, the builds will continue to fail due to the system being unable to pull the required images.
-
-.Procedure
-
-. Obtain the username and password login credentials for the container registry.
-    * For access to `registry.redhat.io`, you can create a registry service account at https://access.redhat.com/terms-based-registry/accounts.
-. In the correct {ProductName} workspace, go to **Secrets**. 
-. Click **Add secret**.  
-. For **Secret type**, select **Image pull secret**.
-. For **Authentication type**, select **Image registry credentials**.
-. For **Registry server address** enter the image registry (for example `registry.redhat.io`).
-. Enter the username for the registry in **Username**.
-. Enter the password for the registry in **Password**.
-. Click **Add secret**.
-
-
-[NOTE]
-====
-Performing this operation through the UI will link the secret to the `appstudio-pipeline`
-`serviceaccount` automatically. If you instead wanted to add manually the secret to the
-namespace (creating the `secret` directly on the tenant
-workspace), you'll need to have the secret linked manually.
-
-please review the xref:/troubleshooting/index.adoc#check-if-the-secret-is-linked-to-the-service-account[troubleshooting section]) for more info.
-====
-
-== Creating source control secrets
-
-When building content from GitHub, you will need to install an application for Pipelines as Code in your repository. For supported source control management platforms that do not have an application, however, access tokens will need to be added to your {ProductName} workspace before creating your component.
-
-.Prerequisites
-
-* You have completed the steps listed in the xref:/getting-started/cli.adoc[Getting started in the CLI] page.
-
-.Procedure (GitLab)
-
-. In GitLab click on Settings -> Access Tokens on the left menu of your repository. **NOTE:** if you don't see this option, you need someone with permissions to do so.
-. Then click on `Add new token`.
-. Select the following scopes: `api`, `read_repository`, and `write_repository`.
-. If your GitLab instance supports setting token roles, set the role to `Maintainer`.
-. Select **Create project access token**.
-. Add a token to your {ProductName} workspace by running the `kubectl create` command and creating a new YAML file with a secret:
-
-+
-[source,bash]
-----
-kubectl create -f GL-secret.yaml
-----
-
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
+yaml
+Copy
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
 metadata:
-  name: pipelines-as-code-secret
-  namespace: <YOUR NAMESPACE>
-  labels:
-    appstudio.redhat.com/credentials: scm
-    appstudio.redhat.com/scm.host: <source-control-management-host> # for example, gitlab.com
-type: kubernetes.io/basic-auth
-stringData:
-  password: <PROJECT ACCESS TOKEN>
-----
+  name: sast-snyk-check
+spec:
+  taskRef:
+    name: sast-snyk-check
+  params:
+    - name: snyk_token
+      valueFrom:
+        secretKeyRef:
+          name: sast_snyk_task
+          key: snyk_token
+Best Practices
+Security: Always ensure that secrets are stored securely.
 
-+
-[NOTE]
-====
-Using the PAT authentication requires only the `password` key. The `username` should not be set. If you set both the `username` and `password` keys, the authentication type will be considered as `basic`, and a basic authentication client will be created using those credentials. This client might not work or can be considered as a deprecated login method by some Source Code Management (SCM) providers.
-====
+Naming Conventions: Use consistent naming conventions for secrets.
 
-This secret will be used by the build service to perform builds with Pipeline-as-Code.
+Access Control: Limit access to secrets to only those who need them.
 
-This Project Access Tokens are scoped to a project, so you cannot use them to access resources from other projects. For more information regarding Project Access Tokens, see the Gitlab https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html[documentation].
+Troubleshooting
+Common Issues
+Secrets not being recognized by tasks.
 
-It is also possible to have secrets for per-repository or organization access. To do this, a `appstudio.redhat.com/scm.repository` annotation should be added to the secret. It may either specify the full repository path or the partial path with a wildcard. For example, to create a secret for all repositories in the `my-user` organization, create (or add) the following YAML file:
+Incorrect secret names or keys.
 
+Debugging Tips
+Check the secret name and key in the pipeline YAML.
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: pipelines-as-code-secret
-  namespace: <YOUR NAMESPACE>
-  labels:
-    appstudio.redhat.com/credentials: scm
-    appstudio.redhat.com/scm.host: <source-control-management-host> # for example, gitlab.com
-  annotations:
-    appstudio.redhat.com/scm.repository: my-user/*
-type: kubernetes.io/basic-auth
-stringData:
-  password: <PROJECT ACCESS TOKEN>
-----
+Verify that the secret exists in the correct namespace.
 
-For a specific repository, the following secret should be created:
+Additional Resources
+Konflux GitHub repository
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: pipelines-as-code-secret
-  namespace: <YOUR NAMESPACE>
-  labels:
-    appstudio.redhat.com/credentials: scm
-    appstudio.redhat.com/scm.host: <source-control-management-host> # for example, gitlab.com
-  annotations:
-    appstudio.redhat.com/scm.repository: <repository-path> # for example, my-user/my-repo
-type: kubernetes.io/basic-auth
-stringData:
-  password: <PROJECT ACCESS TOKEN>
-----
+Tekton documentation
 
-[NOTE]
-====
-* You can have multiple repositories listed under the `appstudio.redhat.com/scm.repository` annotation. Separate repository names with commas when listing them. The secret will be used for all repositories that match the specified paths.
+GitLab Project Access Tokens
 
-* You can also have multiple secrets with different labels and/or annotations. In order to work, at least the additional ones, need to be named with `pipeline-as-code-secret` as prefix (for example pipeline-as-code-secret-xxx).
-====
-
-[IMPORTANT]
-==== 
-* Secrets lookup mechanism is searching for the most specific secret first. The secret with a repository annotation will be used first if it matches the component repository path. In none found, then a lookup will try to find a secret with a wildcard, or just the host matching one.
-
-* If you upload a GitLab access token to a workspace, {ProductName} won’t use the global GitHub application when accessing GitHub repositories.
-====
-
-.Additional resources
-
-* For more information about GitLab access tokens, see link:https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html[Project access tokens].
-
-* To configure push secrets for your Build and Release pipelines, see link:https://github.com/konflux-ci/konflux-ci?tab=readme-ov-file#configuring-a-push-secret-for-the-build-pipeline[Configuring push secrets] in the Konflux GitHub repository.
+Conclusion
+Using secrets correctly in your pipelines is crucial for security and functionality. Follow best practices and refer to the documentation for more details.


### PR DESCRIPTION
We added a tekton task as an example how user can use the created secrets 
within a build or integration pipeline 

[KONFLUX-5917](https://issues.redhat.com/browse/KONFLUX-5917)