### PR TITLE
Fix jump link to rpm prefetching guide

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/configuring/prefetching-dependencies.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/prefetching-dependencies.adoc
@@ -27,7 +27,7 @@ For every build, Cachi2 generates a software bill of materials (SBOM) where all 
 |xref:bundler[bundler]
 |`Ruby`
 
-|xref:rpm*[rpm]
+|xref:rpm[rpm]*
 |`N/A`
 
 |xref:generic[generic]


### PR DESCRIPTION
The asterisk prevented jumping to the linked section.