### PR TITLE
doc(konflux-5673): document process for accessing private repo

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/_nav.adoc
+++ b/docs/modules/ROOT/pages/how-tos/_nav.adoc
@@ -25,6 +25,7 @@
 **** xref:how-tos/testing/integration/debugging.adoc[Debugging an integration test]
 **** xref:how-tos/testing/integration/rerunning.adoc[Rerunning an integration test]
 **** xref:how-tos/testing/integration/choosing-contexts.adoc[Choosing when to run certain Integration Tests]
+**** xref:how-tos/testing/integration/accessing-private-repositories.adoc[Accessing Pipelines and Tasks in Private Repositories]
 **** Snapshots
 ***** xref:how-tos/testing/integration/snapshots/working-with-snapshots.adoc[Working with Snapshots]
 ***** xref:how-tos/testing/integration/snapshots/override-snapshots.adoc[Creating an override snapshot]

--- a/docs/modules/ROOT/pages/how-tos/testing/integration/accessing-private-repositories.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/accessing-private-repositories.adoc
@@ -1,0 +1,79 @@
+= Access Pipelines and Tasks in Private Repositories
+
+Integration Test Scenarios point to their corresponding pipeline with a link:https://tekton.dev/docs/pipelines/git-resolver/[Git Resolver]. The Git Resolver schema is inherited from Tekton and functions in the same way. Users should create an access token for their repository in link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens[Github] or link:https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html[Gitlab] then link:../configuring/creating-secrets.adoc#creating-source-control-secrets[store that token in a secret] in their namespace.
+
+Once this is done, the Resolver should be updated with the fields `token` and `tokenKey`, which provide the name of the secret and the key within the `data` section of that secret in which the access token is stored.
+
+== Example of Resolver in IntegrationTestScenario
+
+[source,yaml]
+.its.yaml
+
+----
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: example-pass
+  namespace: default
+spec:
+  application: application-sample
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    resolver: git
+    params:
+      - name: org
+        value: konflux-ci
+      - name: repo
+        value: sample-private-repo
+      - name: serverURL
+        value: https://github.com
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/integration_pipeline_pass.yaml
+      - name: token
+        value: ${SECRET_NAME}
+      - name: tokenKey
+        value: ${SECRET_KEY}
+----
+
+== Example of Resolver in Pipeline
+
+This is an example of how tasks in private repos can be accessed with the Git Resolver using the same method as above.
+
+[source,yaml]
+.pipeline.yaml
+
+----
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: deploy-and-test
+spec:
+  description: |
+    Demonstrates the use of Git Resolvers to access tasks in private repos
+  tasks:
+    - name: parse-metadata
+        taskRef:
+          resolver: git
+          params:
+            - name: org
+              value: konflux-ci
+            - name: repo
+              value: sample-private-repo
+            - name: serverURL
+              value: https://github.com
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: tasks/test_metadata.yaml
+            - name: token
+              value: ${SECRET_NAME}
+            - name: tokenKey
+              value: ${SECRET_KEY}
+        params:
+          - name: SNAPSHOT
+            value: $(params.SNAPSHOT)
+----


### PR DESCRIPTION
There has been lots of user confusion about how to access pipelines in private repos from the Integration Test Scenarios.  This document outlines the process on how to do it and links to the Tekton Git Resolver documentation, which contains a bit more information on how Git Resolvers work