### PR TITLE
Ensure that xref is used to refence doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ deploy.json
 # Vale styles
 .vale/styles/*
 !.vale/styles/config
+!.vale/styles/Konflux

--- a/.vale.ini
+++ b/.vale.ini
@@ -12,4 +12,4 @@ Vocab = konflux
 
 [*.adoc]
 
-BasedOnStyles = RedHat
+BasedOnStyles = RedHat, Konflux

--- a/.vale/styles/Konflux/UpstreamLinks.yml
+++ b/.vale/styles/Konflux/UpstreamLinks.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: Replace URL of upstream doc '%s' with 'xref:ROOT:relative/path/to/upstream/file.adoc'. 
+level: error
+ignorecase: true
+nonword: true
+scope: raw
+tokens:
+  - 'https:\/\/konflux-ci\.dev\/docs\/[-_\w/]+'
+

--- a/docs/modules/ROOT/pages/how-tos/configuring/hermetic-builds.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/hermetic-builds.adoc
@@ -17,7 +17,7 @@ spec:
 
 [IMPORTANT]
 ====
-* Hermetic builds disable network access, so a build with dependencies outside of its Git repository--including supported languages--might fail. To prevent this, or to pull in dependencies from a package manager for one of the xref:how-tos/configuring/prefetching-dependencies.adoc#supported-languages[supported languages], follow the instructions in link:https://konflux-ci.dev/docs/how-tos/configuring/prefetching-dependencies/[Prefetching the package manager dependencies for the hermetic build].
+* Hermetic builds disable network access, so a build with dependencies outside of its Git repository--including supported languages--might fail. To prevent this, or to pull in dependencies from a package manager for one of the xref:how-tos/configuring/prefetching-dependencies.adoc#supported-languages[supported languages], follow the instructions in xref:ROOT:how-tos/configuring/prefetching-dependencies.adoc[Prefetching the package manager dependencies for the hermetic build].
 +
 Similarly, with a link:https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml[Buildah] task for a non-Java application, when you set the `*hermetic*` parameter to `true`, you’re isolating the build from the network, which restricts it to building only from dependencies listed in your Git repository. 
 

--- a/docs/modules/ROOT/pages/how-tos/testing/integration/choosing-contexts.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/choosing-contexts.adoc
@@ -23,7 +23,7 @@ integration tests manually in xref:how-tos/testing/integration/rerunning.adoc[Re
 NOTE: When multiple contexts are defined, the IntegrationTestScenario will execute if any of the specified contexts match the snapshot. This approach ensures that the test runs as long as at least one context applies, without requiring all defined contexts to be met.
 
 .Prerequisites
-- You have CLI access to the specific OpenShift cluster. For information on obtaining CLI access, refer link:https://konflux-ci.dev/docs/getting-started/cli/[Getting started with the CLI].
+- You have CLI access to the specific OpenShift cluster. For information on obtaining CLI access, refer xref:ROOT:getting-started/cli.adoc[Getting started with the CLI].
 
 .Procedure
 


### PR DESCRIPTION
Not using xref will prevent proper generation of donwstream docs.

It also makes harder to check existence of referenced content.