### PR TITLE
KONFLUX-5692: added new page for how to reference secrets in Containerfile

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/_nav.adoc
+++ b/docs/modules/ROOT/pages/how-tos/_nav.adoc
@@ -15,6 +15,7 @@
 *** xref:how-tos/configuring/overriding-compute-resources.adoc[Overriding compute resources]
 *** xref:how-tos/configuring/activation-keys-subscription.adoc[Using Red Hat subscription content]
 *** xref:how-tos/configuring/reconfiguring-build-pipeline.adoc[Reconfiguring the build pipeline]
+*** xref:how-tos/configuring/referencing-secrets-in-Containerfile.adoc[Referencing secrets in Containerfile]
 ** xref:how-tos/testing/index.adoc[Testing your components and applications]
 *** xref:how-tos/testing/build/index.adoc[Build-time tests]
 **** xref:how-tos/testing/build/snyk.adoc[Enabling Snyk]

--- a/docs/modules/ROOT/pages/how-tos/configuring/referencing-secrets-in-Containerfile.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/referencing-secrets-in-Containerfile.adoc
@@ -8,6 +8,23 @@ There may be times when you need to reference a secret directly in your Containe
 . Set the value of the `ADDITIONAL_SECRET` parameter to the name of the secret that you want to use in your Containerfile.
 . In the Containerfile, use a `RUN` command to mount the secret and make it available for use.
 
+== Example Secrets
+
+For the purposes of these examples we will use a secret named "cryptography" and has two keys, SALT & KEY_HASH. It's is defined like this:
+
+[source,yaml]
+----
+kind: Secret
+apiVersion: v1
+metadata:
+  name: cryptography
+  namespace: <your-workspace-tenant>
+data:
+  SALT: 11111111111
+  KEY_HASH: 11111111111
+type: Opaque
+---
+
 == Example: Setting the ADDITIONAL_SECRET Parameter in the build-container Task
 
 Let's use an example of a cryptographic secret used to customize encryption in a Containerfile.

--- a/docs/modules/ROOT/pages/how-tos/configuring/referencing-secrets-in-Containerfile.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/referencing-secrets-in-Containerfile.adoc
@@ -1,0 +1,49 @@
+= Referencing Secrets in a Containerfile
+
+There may be times when you need to reference a secret directly in your Containerfile. For example, if your build uses cryptographic parameters stored in secrets. This can be accomplished by using the `ADDITIONAL_SECRET` link:https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.4/README.md[param] parameter of the `build-container` task.
+
+.Procedure
+
+. Create the needed secret using link:https://konflux-ci.dev/docs/how-tos/configuring/creating-secrets/[secrets].
+. Set the value of the `ADDITIONAL_SECRET` parameter to the name of the secret that you want to use in your Containerfile.
+. In the Containerfile, use a `RUN` command to mount the secret and make it available for use.
+
+== Example: Setting the ADDITIONAL_SECRET Parameter in the build-container Task
+
+Let's use an example of a cryptographic secret used to customize encryption in a Containerfile.
+
+Given that you have created a secret named `cryptography` that contains various cryptography-related values (such as salts), here is how you would pass it to the `ADDITIONAL_SECRET` parameter in the build-container task in your Tekton pipelines:
+
+[source,yaml]
+----
+...
+  tasks:
+    - name: build-container
+      params:
+        - name: ADDITIONAL_SECRET
+          value: "cryptography"
+...
+----
+
+== Example: Referencing the ADDITIONAL_SECRET in Your Containerfile Using RUN
+
+Building on the example above, we want to use these secrets as environment variables for a Rust cargo build command. We do this by mounting the secrets using the `RUN` command, then setting them as environment variables for the build process. Note that the `cryptography` secret contains two values: `SALT` and `KEY_HASH`. This example shows how to reference them both:
+
+[source,docker]
+----
+# Build with secrets
+RUN --mount=type=secret,id=cryptography/SALT \
+    --mount=type=secret,id=cryptography/KEY_HASH \
+    export SALT="$(cat /run/secrets/cryptography/SALT)" && \
+    export KEY_HASH="$(cat /run/secrets/cryptography/KEY_HASH)" && \
+    cargo build --release
+----
+
+[NOTE]
+====
+Only the `RUN` command can be used to reference the secret in this manner.
+====
+
+== Additional Resources
+
+* For more information about build-container buildah parameters, see link:https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.4/README.md[buildah parameters].


### PR DESCRIPTION
Added a new page and example for how to reference secrets in a Containerfile using ADDITIONAL_SECRET param of build-container task.

See this Jira: https://issues.redhat.com/browse/KONFLUX-5692