### PR TITLE
fix: Override npm Package Name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "konflux-ci-docs",
       "devDependencies": {
         "@antora/collector-extension": "^1.0.1",
         "@antora/lunr-extension": "^1.0.0-alpha.8",
@@ -138,15 +139,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@antora/expand-path-helper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@antora/expand-path-helper/-/expand-path-helper-2.0.0.tgz",
-      "integrity": "sha512-CSMBGC+tI21VS2kGW3PV7T2kQTM5eT3f2GTPVLttwaNYbNxDve08en/huzszHJfxo11CcEs26Ostr0F2c1QqeA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.17.0"
       }
     },
     "node_modules/@antora/file-publisher": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "konflux-ci-docs",
   "devDependencies": {
     "@antora/collector-extension": "^1.0.1",
     "@antora/lunr-extension": "^1.0.0-alpha.8",


### PR DESCRIPTION
- Update `package.json` to keep npm package name consistent.
- Update `package-lock.json` from npm install.