### PR TITLE
feat: Create documentation to help user to schedule periodic Integration tests

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/_nav.adoc
+++ b/docs/modules/ROOT/pages/how-tos/_nav.adoc
@@ -26,6 +26,7 @@
 **** xref:how-tos/testing/integration/rerunning.adoc[Rerunning an integration test]
 **** xref:how-tos/testing/integration/choosing-contexts.adoc[Choosing when to run certain Integration Tests]
 **** xref:how-tos/testing/integration/accessing-private-repositories.adoc[Accessing Pipelines and Tasks in Private Repositories]
+**** xref:how-tos/testing/integration/periodic-integration-tests.adoc[Triggering Periodic Integration Tests]
 **** Snapshots
 ***** xref:how-tos/testing/integration/snapshots/working-with-snapshots.adoc[Working with Snapshots]
 ***** xref:how-tos/testing/integration/snapshots/override-snapshots.adoc[Creating an override snapshot]

--- a/docs/modules/ROOT/pages/how-tos/testing/integration/periodic-integration-tests.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/periodic-integration-tests.adoc
@@ -1,0 +1,134 @@
+= Triggering Periodic Integration Tests
+
+In {ProductName}, you can run integration tests on a schedule using Kubernetes CronJobs.
+
+== Procedure
+
+To trigger a periodic Integration Test, complete the following steps:
+
+. Create an integration test by following the xref:how-tos/testing/integration/creating.adoc[Creating a integration test guide].
+
+[NOTE]
+====
+If the Integration Test is designed to only run periodically rather than during Pull Request checks or post-merge, you need to add the *disabled* xref:how-tos/testing/integration/choosing-contexts.adoc[context] to the Integration Test.
+====
+
+. Create RBAC rules in your tenant to allow CronJob ServiceAccount to access snapshot.
+
+. Create a link:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/[CronJob] that will trigger periodic Integration Tests via xref:how-tos/testing/integration/rerunning.adoc[snapshot labels].
+
+=== Procedure with example
+
+This procedure assumes that you already have an integration test created and a ServiceAccount available in your tenant.
+
+. Create a `Role` and `RoleBinding` to grant the necessary snapshot access to the ServiceAccount, which will be used to trigger the periodic Integration Tests
+[source,yaml]
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: periodic-jobs-role
+  namespace: default-tenant
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: periodic-jobs-rolebinding
+  namespace: default-tenant
+subjects:
+  - kind: ServiceAccount
+    name: default-tenant
+    namespace:
+roleRef:
+  kind: Role
+  name: periodic-jobs-role
+  apiGroup: rbac.authorization.k8s.io
+
+. Create a CronJob that will trigger a Periodic Integration Test scenario via snaphot labels.
+
+The following CronJob example configured to run every two days (`*/2` in the schedule). It triggers an integration test scenario in Konflux by:
+
+- Fetching the latest valid snapshot associated with push events in the specified tenant.
+- Checking if a valid snapshot exists and is autoreleased successfully; if not, the job exits with an error.
+- Labeling the snapshot to initiate the integration test scenario
+
+This process helps ensure that the integration tests are executed periodically using the most recent in main branch.
+
+[source,yaml]
+----
+kind: CronJob
+apiVersion: batch/v1
+metadata:
+  name: periodic-integration-test
+  namespace: default-tenant <.>
+spec:
+  schedule: '0 0 */2 * *'
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: trigger-e2e-scenario
+              image: 'quay.io/konflux-ci/appstudio-utils:latest'
+              imagePullPolicy: Always
+              command:
+                - /bin/bash
+                - '-c'
+              args:
+                - |
+                  #!/bin/bash
+                  set -euo pipefail
+
+                  export KONFLUX_SCENARIO_NAME="integration-test" <.>
+                  export KONFLUX_TENANT_NAME="default-tenant" <.>
+                  export KONFLUX_APPLICATION_NAME="application-default" <.>
+                  export KONFLUX_COMPONENT_NAME="component-default" <.>
+
+                  echo -e "[INFO] Fetching latest snapshot from ${KONFLUX_TENANT_NAME} related to push events."
+
+                  LATEST_SNAPSHOT=$(kubectl get snapshots -n "${KONFLUX_TENANT_NAME}" -o json | \
+                      jq --arg application "$KONFLUX_APPLICATION_NAME" --arg component "$KONFLUX_COMPONENT_NAME" -r '
+                          .items
+                          | map(select(
+                              .metadata.labels."appstudio.openshift.io/application" == $application and
+                              .metadata.labels."appstudio.openshift.io/component" == $component and
+                              .metadata.labels."pac.test.appstudio.openshift.io/event-type" == "push" and
+                              (.status.conditions // [] | map(select(
+                                  .type == "AutoReleased" and
+                                  .reason == "AutoReleased" and
+                                  .status == "True"
+                                  ))
+                              | length > 0)
+                              ))
+                          | sort_by(.metadata.creationTimestamp) | last | .metadata.name')
+
+                  if [[ -z "${LATEST_SNAPSHOT}" || "${LATEST_SNAPSHOT}" == "null" ]]; then
+                    echo -e "[ERROR] No valid snapshot found. The job will not be triggered."
+                    exit 1
+                  fi
+
+                  echo -e "[INFO] Triggering test scenario ${KONFLUX_SCENARIO_NAME} from snapshot ${LATEST_SNAPSHOT}."
+
+                  kubectl -n "${KONFLUX_TENANT_NAME}" label snapshot "${LATEST_SNAPSHOT}" test.appstudio.openshift.io/run="${KONFLUX_SCENARIO_NAME}"
+
+                  echo "[INFO] Integration Service E2E tests successfully triggered!"
+          serviceAccountName: default
+          serviceAccount: default
+----
+<.> The name of the tenant.
+<.> The Integration Test name to be triggered by the CronJob.
+<.> The tenant from where to annotate the component snapshot to trigger Periodic Integration Test.
+<.> The {ProductName} application name associated with the Integration Test that will be triggered by the CronJob.
+<.> The {ProductName} componet name.
+
+Once the CronJob is triggered and completes, your integration test pipelines should begin executing in the {ProductName} UI.


### PR DESCRIPTION
This Pull Request create documentation about how to run Periodic Integration tests using Kubernetes Cronjob.

Jira issue: https://issues.redhat.com/browse/KFLUXDP-198