### PR TITLE
Change testing farm docs link

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/testing/integration/third-parties/testing-farm.adoc
+++ b/docs/modules/ROOT/pages/how-tos/testing/integration/third-parties/testing-farm.adoc
@@ -1,3 +1,3 @@
 = Testing Farm
 
-In order to learn how to xref:/how-tos/testing/integration/adding.adoc[add a custom integration test] in {ProductName} that uses link:https://docs.testing-farm.io/[Testing Farm], please see link:https://gitlab.com/testing-farm/integrations/tekton#user-content-usage-in-konflux-ci[gitlab.com/testing-farm/integrations/tekton].
+In order to learn how to xref:/how-tos/testing/integration/adding.adoc[add a custom integration test] in {ProductName} that uses link:https://docs.testing-farm.io/[Testing Farm], please see link:https://gitlab.com/testing-farm/integrations-konflux#user-content-usage-in-konflux-ci[gitlab.com/testing-farm/integrations/tekton].


### PR DESCRIPTION
Testing Farm Team needed to move the repo because the ArtifactsHub doesn't support subgroups in GitLab