### PR TITLE
Move component, application, imagerepository CRs into partials

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/configuring/configuration-as-code.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configuring/configuration-as-code.adoc
@@ -72,28 +72,7 @@ If you are creating more than one component, it is likely that your components w
 
 Define this base in `base/component.yaml`. It typically follows a pattern similar to the following:
 
-[source,yaml]
-----
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: Component
-metadata:
-  annotations:
-    image.redhat.com/generate: "true"
-    build.appstudio.openshift.io/request: configure-pac
-  name: example-component
-spec:
-  componentName: example-component
-  application: appName
-  targetPort: 8080
-  source:
-      git:
-        url: gitUrl
-        context: ./
-        dockerfileUrl: ContainerFileLocation
-        revision: defaultBranch
-----
-
-NOTE: This creates a component with a custom build pipeline. If you want to use the default build, omit the `build.appstudio.openshift.io/request: configure-pac` annotation.
+include::ROOT:partial$custom-resources/{context}-component.adoc[]
 
 === Creating Your Base Kustomization
 
@@ -116,16 +95,7 @@ You can think of each application variant as the base that defines the structure
 
 Create your base application at `overlay/application-a/application-a-base/application.yaml` like the following:
 
-[source,yaml]
-----
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: Application
-metadata:
-  name: base
-spec:
-  description: base
-  displayName: base
-----
+include::ROOT:partial$custom-resources/{context}-application.adoc[]
 
 And its Kustomization file at `overlay/application-a/application-a-base/kustomization.yaml`:
 

--- a/docs/modules/ROOT/pages/how-tos/creating.adoc
+++ b/docs/modules/ROOT/pages/how-tos/creating.adoc
@@ -54,79 +54,29 @@ NOTE: GitHub and GitLab are supported source control providers. GitLab support r
 
 .*Procedures*
 
-. Create an `ApplicationComponent.yaml` file locally.
+. Create an `Application.yaml`, `Component.yaml`, and `ImageRepository.yaml` files locally.
 
 +
-*Example `ApplicationComponent.yaml` object*
+*Example `Application.yaml` object*
++
+include::ROOT:partial$custom-resources/{context}-application.adoc[]
 
 +
-[source,yaml]
---
----
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: Application <.>
-metadata:
-  name: <application-name>
-  namespace: <namespace>
-  annotations:
-    application.thumbnail: "1"
-spec:
-  displayName: <application-name>
----
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: Component <.>
-metadata:
-  name: <component-name>
-  namespace: <namespace>
-  annotations:
-    build.appstudio.openshift.io/request: configure-pac
-    build.appstudio.openshift.io/pipeline: '{"name":"<name-of-the-pipeline-to-use>","bundle":"latest"}' <.>
-spec:
-  application: <owning-application-name> <.>
-  componentName: <component-name>
-  source:
-    git:
-      url: https://github.com/konflux-ci/testrepo.git <.>
-      revision: main <.>
-      context: ./ <.>
-      dockerfileUrl: Containerfile <.>
-  containerImage: <oci-repository-to-push-image-to> <.> 
----
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: ImageRepository <.>
-metadata:
-  annotations:
-    image-controller.appstudio.redhat.com/update-component-image: 'true'
-  name: <component-name>
-  namespace: <namespace>
-  labels:
-    appstudio.redhat.com/application: <application-name>
-    appstudio.redhat.com/component: <component-name>
-spec:
-  image:
-    name: <namespace>/<component-name>
-    visibility: public <.>
---
+*Example `Component.yaml` object*
++
+include::ROOT:partial$custom-resources/{context}-component.adoc[]
 
 +
-<.> At least one application should be created. Multiple applications can be created by adding additional CR specifications.
-<.> A component is required to map to a git repository to build.
-<.> Optional: If used, it should point to a xref:/advanced-how-tos/installing/enabling-builds.adoc#customize-pipelines[configured pipeline]. If not specified, the default configured pipeline will be used.
-<.> Each component belongs to _one_ application. That application should be defined in the same file if it does not already exist.
-<.> URL for the source repository. This MUST use the `https://[...]` format for cloning a repository.
-<.> Optional: Branch to build in the repository. If not specified, the default branch will be used.
-<.> Optional: The context to build within the git repository. If not specified, the default defined in the configured pipeline will be used.
-<.> Optional: Path to the Containerfile within the context. If not specified, the default value of "Dockerfile" will be used.
-<.> Optional: If the xref:/advanced-how-tos/installing/enabling-builds.adoc#enable-image-controller[image controller] is not deployed, this is required. You must create a xref:/how-tos/configuring/creating-secrets.adoc#creating-registry-pull-secrets[registry secret] that has permissions to push and pull for the specified path. If an ImageRepository is created, this should be omitted.
-<.> Optional: If the `spec.containerImage` has been defined for the component, this should not be created. If the xref:/advanced-how-tos/installing/enabling-builds.adoc#enable-image-controller[image controller] is not deployed, this custom resource will have no effect.
-<.> Supported values are "public" and "private".
+*Example `ImageRepository.yaml` object*
++
+include::ROOT:partial$custom-resources/{context}-imagerepository.adoc[]
 
-. In your workspace, save the `ApplicationComponent.yaml` file and add the resource to your cluster by running the following command:
+. In your workspace, save the `Application.yaml`, `Component.yaml`, and `ImageRepository.yaml` files and add the resource to your cluster by running the following command:
 
 +
 [source,shell]
 ----
-$ kubectl apply -f ApplicationComponent.yaml
+$ kubectl apply -f Application.yaml -f Component.yaml -f ImageRepository.yaml
 ----
 
 +

--- a/docs/modules/ROOT/partials/custom-resources/konflux-application.adoc
+++ b/docs/modules/ROOT/partials/custom-resources/konflux-application.adoc
@@ -1,0 +1,14 @@
+[source,yaml]
+----
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application <.>
+metadata:
+  name: <application-name>
+  namespace: <namespace>
+  annotations:
+    application.thumbnail: "1"
+spec:
+  displayName: <application-name>
+----
++
+<.> At least one application should be created. Multiple applications can be created by adding additional CR specifications.

--- a/docs/modules/ROOT/partials/custom-resources/konflux-component.adoc
+++ b/docs/modules/ROOT/partials/custom-resources/konflux-component.adoc
@@ -1,0 +1,30 @@
+[source,yaml]
+----
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component <.>
+metadata:
+  name: <component-name>
+  namespace: <namespace>
+  annotations:
+    build.appstudio.openshift.io/request: configure-pac
+    build.appstudio.openshift.io/pipeline: '{"name":"<name-of-the-pipeline-to-use>","bundle":"latest"}' <.>
+spec:
+  application: <owning-application-name> <.>
+  componentName: <component-name>
+  source:
+    git:
+      url: https://github.com/konflux-ci/testrepo.git <.>
+      revision: main <.>
+      context: ./ <.>
+      dockerfileUrl: Containerfile <.>
+  containerImage: <oci-repository-to-push-image-to> <.> 
+----
++
+<.> A component is required to map to a git repository to build.
+<.> Optional: If used, it should point to a xref:/advanced-how-tos/installing/enabling-builds.adoc#customize-pipelines[configured pipeline]. If not specified, the default configured pipeline will be used.
+<.> Each component belongs to _one_ application. That application should be defined in the same file if it does not already exist.
+<.> URL for the source repository. This MUST use the `https://[...]` format for cloning a repository.
+<.> Optional: Branch to build in the repository. If not specified, the default branch will be used.
+<.> Optional: The context to build within the git repository. If not specified, the default defined in the configured pipeline will be used.
+<.> Optional: Path to the Containerfile within the context. If not specified, the default value of "Dockerfile" will be used.
+<.> Optional: If the xref:/advanced-how-tos/installing/enabling-builds.adoc#enable-image-controller[image controller] is not deployed, this is required. You must create a xref:/how-tos/configuring/creating-secrets.adoc#creating-registry-pull-secrets[registry secret] that has permissions to push and pull for the specified path. If an ImageRepository is created, this should be omitted.

--- a/docs/modules/ROOT/partials/custom-resources/konflux-imagerepository.adoc
+++ b/docs/modules/ROOT/partials/custom-resources/konflux-imagerepository.adoc
@@ -1,0 +1,20 @@
+[source,yaml]
+----
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ImageRepository <.>
+metadata:
+  annotations:
+    image-controller.appstudio.redhat.com/update-component-image: 'true'
+  name: <component-name>
+  namespace: <namespace>
+  labels:
+    appstudio.redhat.com/application: <application-name>
+    appstudio.redhat.com/component: <component-name>
+spec:
+  image:
+    name: <namespace>/<component-name>
+    visibility: public <.>
+----
++
+<.> Optional: If the `spec.containerImage` has been defined for the component, this should not be created. If the xref:/advanced-how-tos/installing/enabling-builds.adoc#enable-image-controller[image controller] is not deployed, this custom resource will have no effect.
+<.> Supported values are "public" and "private".


### PR DESCRIPTION
This will help to ensure that CR definitions are consistent across multiple pages. It will also allow other documentation pages to update the CRs with any additional requirement that those systems might want to impose.