### PR TITLE
Fix incorrect partial includes

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -26,4 +26,4 @@ To access {ProductName}, your PE needs to give you the URL to your team's instan
 
 == Getting started with the CLI
 
-include:partial$getting-started/{context}-getting-started-with-the-cli.adoc[]
+include::partial${context}-getting-started-with-the-cli.adoc[]

--- a/modules/building/pages/configuration-as-code.adoc
+++ b/modules/building/pages/configuration-as-code.adoc
@@ -72,7 +72,7 @@ If you are creating more than one component, it is likely that your components w
 
 Define this base in `base/component.yaml`. It typically follows a pattern similar to the following:
 
-include:partial$custom-resources/{context}-component.adoc[]
+include::partial$custom-resources/{context}-component.adoc[]
 
 === Creating Your Base Kustomization
 
@@ -95,7 +95,7 @@ You can think of each application variant as the base that defines the structure
 
 Create your base application at `overlay/application-a/application-a-base/application.yaml` like the following:
 
-include:partial$custom-resources/{context}-application.adoc[]
+include::partial$custom-resources/{context}-application.adoc[]
 
 And its Kustomization file at `overlay/application-a/application-a-base/kustomization.yaml`:
 

--- a/modules/building/pages/creating-secrets.adoc
+++ b/modules/building/pages/creating-secrets.adoc
@@ -214,7 +214,7 @@ stringData:
 * If you upload a GitLab access token to a workspace, {ProductName} won’t use the global GitHub application when accessing GitHub repositories.
 ====
 
-include:partial$building/{context}-secrets-external-vault.adoc[]
+include::partial${context}-secrets-external-vault.adoc[]
 
 == Additional resources
 

--- a/modules/building/pages/creating.adoc
+++ b/modules/building/pages/creating.adoc
@@ -59,17 +59,17 @@ NOTE: GitHub and GitLab are supported source control providers. GitLab support r
 +
 *Example `Application.yaml` object*
 +
-include:partial$custom-resources/{context}-application.adoc[]
+include::partial$custom-resources/{context}-application.adoc[]
 
 +
 *Example `Component.yaml` object*
 +
-include:partial$custom-resources/{context}-component.adoc[]
+include::partial$custom-resources/{context}-component.adoc[]
 
 +
 *Example `ImageRepository.yaml` object*
 +
-include:partial$custom-resources/{context}-imagerepository.adoc[]
+include::partial$custom-resources/{context}-imagerepository.adoc[]
 
 . In your workspace, save the `Application.yaml`, `Component.yaml`, and `ImageRepository.yaml` files and add the resource to your cluster by running the following command:
 

--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -259,12 +259,12 @@ To prefetch dependencies for a component build, complete the following steps:
 
 . Have a Containerfile, for example:
 +
-include:partial$building/{context}-example-prefetch-rpm-containerfile.adoc[]
+include:::partial${context}-example-prefetch-rpm-containerfile.adoc[]
 
 . Create a `rpms.in.yaml` file in your git repository, with the following contents:
 
 +
-include:partial$building/{context}-example-prefetch-rpm-rpms_in_yaml.adoc[]
+include:::partial${context}-example-prefetch-rpm-rpms_in_yaml.adoc[]
 <1> The `*packages*` list is the list of packages you want to install in your Container. You don't have to declare transitive dependencies here. The rpm-lockfile-prototype tool will resolve them for you.
 <2> This should be a reference to a repo file, like those found in `/etc/yum.repos.d/`. This tells the tooling where to find your rpm and its dependencies.
 <3> The `arches` array allows you to specify which architectures the dependencies should be downloaded for. If you're building a multi-arch container this array is mandatory, otherwise the build task will fail.
@@ -275,7 +275,7 @@ https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#whats-th
 . Copy any necessary yum/dnf repo files into your git repository. For example:
 
 +
-include:partial$building/{context}-example-prefetch-rpm-copy-repo.adoc[]
+include:::partial${context}-example-prefetch-rpm-copy-repo.adoc[]
 
 +
 NOTE: For every repository defined in your set of repo files, make sure to add the corresponding sources repo (or make sure to enable them, if they’re already present). Otherwise, the lockfile generator will not include any SRPMs in your lockfile, cachi2 won’t download any SRPMs and the source container for your build will be incomplete.
@@ -283,12 +283,12 @@ NOTE: For every repository defined in your set of repo files, make sure to add t
 . Run the following command to resolve your `rpms.in.yaml` file and produce a `rpms.lock.yaml` file.
 
 +
-include:partial$building/{context}-example-prefetch-rpm-execute.adoc[]
+include:::partial${context}-example-prefetch-rpm-execute.adoc[]
 <1> The produced `rpms.lock.yaml` file will include only your requested dependency plus its transitive dependencies, minus any rpms that are already installed in the provided base image.
 +
 Example of generated lockfile:
 +
-include:partial$building/{context}-example-prefetch-rpm-lockfile.adoc[]
+include:::partial${context}-example-prefetch-rpm-lockfile.adoc[]
 +
 NOTE: The list of `arches.packages` is omitted for brevity.
 

--- a/modules/end-to-end/nav.adoc
+++ b/modules/end-to-end/nav.adoc
@@ -1,3 +1,3 @@
 ** End-to-end guides
 *** xref:end-to-end:building-olm.adoc[Building an OLM operator]
-include:partial$end-to-end/{context}-nav.adoc[]
+include::partial${context}-nav.adoc[]

--- a/modules/patterns/pages/git-submodules.adoc
+++ b/modules/patterns/pages/git-submodules.adoc
@@ -34,7 +34,7 @@ By the end of this guide, you will have created a downstream repository which do
 * uses the contents of the git submodule in a Containerfile for further edits.
 * is onboarded to {ProductName} for builds.
 
-include:partial$patterns/{context}-submodules-source-control.adoc[]
+include::partial${context}-submodules-source-control.adoc[]
 
 === Create the git submodule for the upstream repository to track it
 
@@ -56,7 +56,7 @@ Check and configure the git submodule config:
   branch = <upstream-repository-branch>
 ----
 
-include:partial$patterns/{context}-submodules-renovate.adoc[]
+include::partial${context}-submodules-renovate.adoc[]
 
 NOTE: See the link:https://git-scm.com/docs/gitsubmodules[Git documentation] for more details on configuring git submodules.
 
@@ -91,7 +91,7 @@ ENTRYPOINT ["<entrypoint-executable>"]
 
 You should be able to prove to yourself that the downstream Containerfile builds locally with `podman build .`.
 
-include:partial$patterns/{context}-submodules-example-downstream-containerfile.adoc[]
+include::partial${context}-submodules-example-downstream-containerfile.adoc[]
 
 === Onboard the component onto {ProductName}
 
@@ -107,7 +107,7 @@ build pipeline to use the upstream Containerfile with downstream args at build
 time. This has the advantage of not having to maintain a copy of the
 Containerfile in the downstream repo.
 
-include:partial$patterns/{context}-submodules-example-args-file.adoc[]
+include::partial${context}-submodules-example-args-file.adoc[]
 
 === Using private repositories as a git submodule:
 

--- a/modules/reference/pages/sample-repositories.adoc
+++ b/modules/reference/pages/sample-repositories.adoc
@@ -17,4 +17,4 @@ code referenced by a git submodule.
 
 https://github.com/konflux-ci/olm-operator-konflux-sample
 
-include:partial$reference/{context}-additional-sample-repositories.adoc[]
+include::partial${context}-additional-sample-repositories.adoc[]


### PR DESCRIPTION
During the refactoring done in xxx, some of the includes were incorrectly written as "include:" instead of "include::". Also, by moving the partials to their respective modules, the previous folder they were placed at is no longer part of the path.

See more info a the official Antora [docs](https://docs.antora.org/antora/latest/page/include-a-partial/).
