### PR TITLE
doc: schedule is specific to package rule

### DIFF
--- a/modules/mintmaker/pages/user.adoc
+++ b/modules/mintmaker/pages/user.adoc
@@ -209,7 +209,7 @@ All times are in UTC.
 === Overriding the default schedule
 
 You can override the default MintMaker schedule by modifying the https://docs.renovatebot.com/key-concepts/scheduling/[`schedule`] config option.
-This only changes the manager-specific schedule.
+This only changes the package-rule-specific schedule.
 
 To apply the schedule globally (for all managers), use `schedule` in the top
 level of the config file:


### PR DESCRIPTION
Renovate schedule can be set in package rules rather than manager configs.