### PR TITLE
Document how to create activation key secrets to be usable by MintMaker

### DIFF
--- a/modules/building/pages/activation-keys-subscription.adoc
+++ b/modules/building/pages/activation-keys-subscription.adoc
@@ -29,6 +29,7 @@ Sometimes, you only want certain builds to have the activation key, particularly
 ====
 * If you want to use the feature to automatically update xref:ROOT:mintmaker:rpm-lockfile.adoc[RPM lockfiles] containing RPMs that require subscription, you have to include additional labels and annotations so that the xref:ROOT:mintmaker:user.adoc[Dependency Management] service can properly match the activation keys with their repositories. How to create such secrets is explained in the next section.
 * The default secret `+activation-key+` doesn't have such requirements and will be automatically used as a fallback option for all namespace components.
+* Besides correctly setting the secret labels, additional configuration must be performed, as described in xref:ROOT:mintmaker:rpm-lockfile.adoc#rpm-lockfile-with-rpms-that-require-subscription[RPM lockfile with RPMs that require subscription]
 ====
 
 == Create the activation key secrets
@@ -57,7 +58,8 @@ Create custom activation key secrets with extra labels and annotations so that t
 [NOTE]
 ====
 * This procedure is only necessary if you want to have your RPM lockfiles automatically updated by MintMaker. Otherwise, you can create your custom secrets without the extra labels and annotations.
- The default `+activation-key+` secret doesn't need to follow this procedure, it will be applied to all namespaces repositories as a fallback option.
+* The default `+activation-key+` secret doesn't need to follow this procedure, it will be applied to all namespaces repositories as a fallback option.
+* Additional configuration must be performed, as described in xref:ROOT:mintmaker:rpm-lockfile.adoc#rpm-lockfile-with-rpms-that-require-subscription[RPM lockfile with RPMs that require subscription]
 ====
 These secrets can only be created through the CLI:
 

--- a/modules/mintmaker/pages/rpm-lockfile.adoc
+++ b/modules/mintmaker/pages/rpm-lockfile.adoc
@@ -33,3 +33,19 @@ Please find how to generate RPM lockfile in xref:ROOT:building:prefetching-depen
 Some projects require having multiple lockfiles in different subdirectories.
 These lockfiles will be updated, however matching CVE data against them
 is xref:mintmaker:support.adoc#rpm-lock-files[not currently supported].
+
+== RPM lockfile with RPMs that require subscription
+
+MintMaker is able to update RPM lockfiles containing RPMs that require subscription, but some setup needs to be completed first. Firstly, activation key secret needs to be added to the user namespace. This process is described in detail in the xref:ROOT:building:activation-keys-subscription.adoc[Using Red Hat activation keys to access subscription content] article. Secondly, the RPM repofile needs to be modified to make use of the custom authentication certificate and key. For each repository requiring authentication, please set `sslclientkey = $SSL_CLIENT_KEY` and `sslclientcert = $SSL_CLIENT_CERT`. This will ensure that MintMaker sets the correct paths for the authentication. For example:
+
+[source]
+----
+[rhel-9-for-x86_64-baseos-rpms]
+name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/x86_64/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT
+----


### PR DESCRIPTION
MintMaker cannot match custom activation key secrets to their repositories without extra labels and annotations. Document how users can create such secrets.

The labels and annotations are analogous to Gitlab secret annotations[1].

[1] https://konflux-ci.dev/docs/building/creating-secrets/#gitlab-source-secret

Refers to CLOUDDST-26090