### PR TITLE
Fix title and callouts on labels and annotations page

### DIFF
--- a/modules/building/pages/labels-and-annotations.adoc
+++ b/modules/building/pages/labels-and-annotations.adoc
@@ -1,4 +1,4 @@
-= Using dynamic labels
+= Labels and annotations
 
 Konflux allows applying some dynamic labels to images derived from properties and params of the build pipeline. The labelling is supported directly by the `LABELS` param of the *build-container* tasks. A supporting *generate-labels* task can optionally be used to produce some dynamic labels.
 
@@ -25,18 +25,18 @@ tasks:
       value: "$(params.dockerfile)"
     - name: HERMETIC
       value: "$(params.hermetic)"
-    - name: LABELS <.>
+    - name: LABELS <1>
       value:
         - from-pull-request=true
         - hermetic-param=$(params.hermetic)
-    - name: ANNOTATIONS <.>
+    - name: ANNOTATIONS <1>
       value:
         - my-annotation=true
         - foo=bar
 ...
 ----
 
-<.> The LABELS and ANNOTATIONS params accepts an array of labels and annotations to be applied to the image after it is built.
+<1> The LABELS and ANNOTATIONS params accepts an array of labels and annotations to be applied to the image after it is built.
 
 [[generating-dynamic-labels-or-annotations]]
 == Generating dynamic labels or annotations


### PR DESCRIPTION
I realized today while checking the new structure I made two mistakes while extending the labels docs with annotations.

First of all, I forgot to change the page title. I changed the section name on the ToC, but not the name on the table itself.
The second one is about the callouts on the code. The callout on the code block are numbered `1` and `2` for labels and annotations but then there is a single explanation for both of them