### PR TITLE
Colorize code links

### DIFF
--- a/antora-lunr-ui/css/main.css
+++ b/antora-lunr-ui/css/main.css
@@ -144,3 +144,12 @@ aside.toc.sidebar {
 .navbar-brand .navbar-item:first-child a {
     margin-top: 5px;
 }
+
+.doc a > code {
+    color: #1565c0;
+}
+
+.doc a > code:hover {
+    color: #104d92;
+    text-decoration: underline;
+}

--- a/antora-lunr-ui/partials/head-styles.hbs
+++ b/antora-lunr-ui/partials/head-styles.hbs
@@ -1,0 +1,2 @@
+    <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+    <link rel="stylesheet" href="{{{uiRootPath}}}/css/main.css">


### PR DESCRIPTION
This brings the colors for code snippets from downstream docs here.

Before:
![image](https://github.com/user-attachments/assets/c7aaab5e-91ba-4c8a-b561-872c71e92c68)

After:
![image](https://github.com/user-attachments/assets/f0344674-2cb6-48af-9b84-e4f36edc05ea)
