### PR TITLE
Add `finally` nuance to slack-webhook-notification

### DIFF
--- a/modules/building/pages/customizing-the-build.adoc
+++ b/modules/building/pages/customizing-the-build.adoc
@@ -138,7 +138,8 @@ An example of a custom task added to the pipeline that sends a slack notificatio
 +
 [source,yaml]
 --
-  name: slack-webhook-notification
+finally:
+- name: slack-webhook-notification
   params:
     - name: message
       value: PipelineRun $(context.pipelineRun.name) failed
@@ -166,6 +167,8 @@ An example of a custom task added to the pipeline that sends a slack notificatio
 [NOTE]
 ====
 * To use `slack-webhook-notification` task, you need to xref:./creating-secrets.adoc[create a secret] in your namespace with at least one key where the value is the webhook URL. For example, to create a secret for Slack, run `kubectl create secret generic my-secret --from-literal dev-team=https://hooks.slack.com/services/XXX/XXXXXX`
+
+* If your build pipeline fans out to anything broader than a straight line (i.e. if you have multiple concurrent tasks), you'll need to add this task under a `finally` clause so that it can aggregate the status of all prior tasks.
 
 * If you want to define a task directly in this file, rather than using `taskRef`, you can use `taskSpec`. See the Tekton documentation on
   link:https://tekton.dev/docs/pipelines/taskruns/#specifying-the-target-task[specifying the target task] for more details.


### PR DESCRIPTION
Simply adding the slack-webhook-notification task as suggested in the original doc will fail with a message like this:

```Tekton Controller has reported this error: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: invalid value: pipeline tasks can not refer to execution status of any other pipeline task or aggregate status of tasks: spec.pipelineSpec.tasks[2].when[0]```

A pipeline that fans out needs to rendezvous and aggregate the status *at the end* to be sure it can catch any failure along the line.