### PR TITLE
Add GitHub App page

### DIFF
--- a/modules/installing/nav.adoc
+++ b/modules/installing/nav.adoc
@@ -1,3 +1,4 @@
 ** Installation
 *** xref:index.adoc[Installing {ProductName}]
 *** xref:enabling-builds.adoc[Enabling build pipelines]
+*** xref:github-app.adoc[GitHub App]

--- a/modules/installing/pages/enabling-builds.adoc
+++ b/modules/installing/pages/enabling-builds.adoc
@@ -1,6 +1,6 @@
 = Enabling build pipelines
 
-Before users can create an application in {ProductName}, you must enable build pipelines in your instance of {ProductName}. At the time of publication, this process includes configuring a smee channel, to listen for users' pull requests, and creating a GitHub App, so {ProductName} can access those PRs.
+Before users can create an application in {ProductName}, you must enable build pipelines in your instance of {ProductName}. At the time of publication, this process includes configuring a smee channel, to listen for users' pull requests, and creating a xref:installing:github-app.adoc[GitHub App], so {ProductName} can access those PRs.
 
 .Prerequisites:
 

--- a/modules/installing/pages/github-app.adoc
+++ b/modules/installing/pages/github-app.adoc
@@ -1,0 +1,20 @@
+= GitHub App
+
+A *GitHub App* is a tool that extends GitHub's functionality. It can do things on GitHub like open issues, comment on pull requests, manage projects, etc.
+
+Learn more about link:https://docs.github.com/en/apps/overview[GitHub Apps].
+
+== Why do we use a GitHub App? [[why-do-we-use-github-app]]
+The Red Hat {ProductName} GitHub App integrates GitHub events (e.g., Push to a branch, Pull Request, etc.) with the link:https://pipelinesascode.com/[Pipelines As Code] (PAC) component. The App allows {ProductName} to perform actions based on your configuration in the `.tekton` folder and integrate {ProductName} updates into your project.
+
+== What does the App do? [[what-does-the-github-app-do]]
+The App provides several key functionalities to enhance your development workflow.
+
+.Some of the features:
+* Initializes Tekton on-pull/on-push PipelineRuns definition during installation
+* Runs Tekton PipelineRuns on your pull requests
+* Tekton PipelineRuns can be run through comments (e.g., `/ok-to-test`, `/retest`)
+* Creates pull requests containing {ProductName} updates
+
+== Where is the App installed? [[where-is-the-app-installed]]
+A GitHub App is installed on a specific repository or an entire organization. Users can manage and configure the app's settings through the repository or organization's settings page under `Installed GitHub Apps`.


### PR DESCRIPTION
Some users encountered difficulties understading/trusting what GitHub App is during UX testing
This page should clarify their concerns

Creating a new subpage should make it easier for users to navigate and could be used later in the UI 

Users had concerns about:
- what the app does
- where is it installed
- whether it is a legitimate request from Red Hat