### PR TITLE
Update rpm prefetch docs

### DIFF
--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -301,6 +301,18 @@ include::partial${context}-example-prefetch-rpm-lockfile.adoc[]
 +
 NOTE: The list of `arches.packages` is omitted for brevity.
 
+. Add/Update the prefetch-input param in the PipelineRun yaml so that the prefetch-task for RPMs is enabled. Update the path if the RPM files are not in the default directory.
+
++
+[source,yaml]
+----
+spec:
+  params:
+    ...
+    - name: prefetch-input
+      value: '{"type": "rpm", "path": "."}' <1>
+----
+
 . Additionally, pass an extra parameter to the `prefetch-dependencies` task in the `.spec.pipelineSpec.tasks` section to indicate that "dev package managers" should be enabled.
 
 +


### PR DESCRIPTION
For users new to prefetch/konflux, it might no be obvious to them to that the`prefetch-input`needs to be set here.

To update this section: https://konflux-ci.dev/docs/building/prefetching-dependencies/#enabling-prefetch-builds-for-rpm