### PR TITLE
Add note about running rpm-lockfile-prototype locally

### DIFF
--- a/modules/mintmaker/pages/rpm-lockfile.adoc
+++ b/modules/mintmaker/pages/rpm-lockfile.adoc
@@ -49,3 +49,9 @@ gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 ----
+
+NOTE: After using variables like these in your repo config, you need to set
+corresponding environment variables if you run the `rpm-lockfile-prototype`
+script manually. These environment variables must be prefixed with `DNF_VAR_`.
+For example, for the `SSL_CLIENT_KEY` variable, you should set an environment
+variable named `DNF_VAR_SSL_CLIENT_KEY`.


### PR DESCRIPTION
Add documentation note explaining how to run rpm-lockfile-prototype locally, when repo config has some variables.