### PR TITLE
fix(315): Restore numbering for custom resource partials

### DIFF
--- a/modules/building/partials/custom-resources/konflux-application.adoc
+++ b/modules/building/partials/custom-resources/konflux-application.adoc
@@ -10,5 +10,4 @@ metadata:
 spec:
   displayName: <application-name>
 ----
-+
 <.> At least one application should be created. Multiple applications can be created by adding additional CR specifications.

--- a/modules/building/partials/custom-resources/konflux-component.adoc
+++ b/modules/building/partials/custom-resources/konflux-component.adoc
@@ -21,7 +21,6 @@ spec:
       dockerfileUrl: Containerfile <.>
   containerImage: <oci-repository-to-push-image-to> <.> 
 ----
-+
 <.> A component is required to map to a git repository to build.
 <.> Optional: If used, it should point to a xref:installing:enabling-builds.adoc#customize-pipelines[configured pipeline]. If not specified, the default configured pipeline will be used.
 <.> Optional: Use if you are building a component from GitLab.

--- a/modules/building/partials/custom-resources/konflux-imagerepository.adoc
+++ b/modules/building/partials/custom-resources/konflux-imagerepository.adoc
@@ -15,6 +15,5 @@ spec:
     name: <namespace>/<component-name>
     visibility: public <.>
 ----
-+
 <.> Optional: If the `spec.containerImage` has been defined for the component, this should not be created. If the xref:installing:enabling-builds.adoc#enable-image-controller[image controller] is not deployed, this custom resource will have no effect.
 <.> Supported values are "public" and "private".


### PR DESCRIPTION
When moving the custom resources to partials, we had the format following the content for the creating page which was in a list. Maintining the indentation continuity broke the rendering when there was no list, however (i.e. configuration as code) pages. Instead of having a `+` to restore the indentation, we can just delete the newline. This will ensure proper context in both types of partial inclusions.

resolves: #315