### PR TITLE
fix: Trusted Artifacts Needed for Custom Tasks

### DIFF
--- a/modules/building/pages/customizing-the-build.adoc
+++ b/modules/building/pages/customizing-the-build.adoc
@@ -99,7 +99,13 @@ NOTE: This example shows a separate Pipeline file, but your pipeline may also be
 
 == Extending the build pipeline with your own tasks
 
-Before you extend your build pipeline, be aware that doing so may cause builds to fail a link:https://conforma.dev/docs[Conforma] check, if you are using Conforma. To resolve this issue, please reference the xref:./customizing-the-build.adoc#preventing-issues-with-conforma[next procedure].
+.Prerequisites
+
+. (optional) Ensure your build pipeline is using
+  xref:./using-trusted-artifacts.adoc[Trusted Artifacts]. This can prevent subsequent failures
+  reported by link:https://conforma.dev/docs/ec-policies/release_policy.html#trusted_task__trusted[Conforma's Trusted Tasks]
+  check. See xref:./customizing-the-build.adoc#preventing-issues-with-conforma[Preventing Issues with Conforma]
+  for more information.
 
 .Procedure
 


### PR DESCRIPTION
Add migrating to Trusted Artifacts as an optional prerequisite step before adding custom tasks. This should prevent future Conforma check failures from occurring.