### PR TITLE
Change the website title to "Konflux Documentation"

### DIFF
--- a/antora-lunr-ui/partials/header-content.hbs
+++ b/antora-lunr-ui/partials/header-content.hbs
@@ -8,7 +8,7 @@
               <span></span>
             </button>
             <img src="{{uiRootPath}}/img/logo.svg" class="navbar-logo" alt="Konflux logo">
-            <a href="{{site.url}}/">{{site.title}}</a>
+            <a href="{{site.url}}/">Documentation</a>
           </div>
         </div>
     <div id="topbar-nav" class="navbar-menu">

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -20,7 +20,7 @@ runtime:
   log:
     failure_level: warn
 site:
-  title: Documentation
+  title: Konflux Documentation
   url: https://konflux-ci.dev/docs
   robots: allow
 content:


### PR DESCRIPTION
This change will affect the name that is displayed in the browser tab.

Since the added "Konflux" will be redundant with the logo that is displayed in the site's header (making it show as "Konflux Konflux Documentation"), we need to disassociate the rendering of the header with the site's configured title.