### PR TITLE
Gitlab PAT: add note about project push rules

### DIFF
--- a/modules/building/pages/creating-secrets.adoc
+++ b/modules/building/pages/creating-secrets.adoc
@@ -212,6 +212,8 @@ stringData:
 * Secrets lookup mechanism is searching for the most specific secret first. The secret with a repository annotation will be used first if it matches the component repository path. In none found, then a lookup will try to find a secret with a wildcard, or just the host matching one.
 
 * If you upload a GitLab access token to a workspace, {ProductName} won’t use the global GitHub application when accessing GitHub repositories.
+
+* If your GitLab project uses restrictive link:https://docs.gitlab.com/ee/user/project/repository/push_rules.html[push rules] to verify users, Konflux may fail to push commits to your repository.
 ====
 
 include::partial${context}-secrets-external-vault.adoc[]


### PR DESCRIPTION
Restrictive push rules in a Gitlab project can cause Konflux to fail to push to a repository.