### PR TITLE
The following documentation updates aim to capture the learnings from

### DIFF
--- a/modules/building/pages/custom-tags.adoc
+++ b/modules/building/pages/custom-tags.adoc
@@ -1,87 +1,87 @@
+[[custom-tags]]
 = Using custom tags
 
-Konflux allows tagging built images with custom tags. This tagging is handled by separate *apply-tags* task. The custom tags can be configured in two ways:
+Konflux-CI build pipelines allow you to apply multiple tags to your container images. Beyond the default tag (often the commit SHA or `latest`), you can define custom tags based on Git metadata or other build parameters. This is typically achieved using the `apply-tags` task.
 
-. <<using-konflux-label>>
-. <<using-additional-tags-parameter>>
+.Prerequisites
+* Your build pipeline (`build-pipeline.yaml` or similar) is defined and version-controlled in your repository.
+* Your pipeline includes a task for cloning the Git repository (e.g., `clone-repository`) that provides results like commit timestamp and branch/revision information.
+* Your pipeline includes a parameter for versioning, for example, `artifact-version`.
 
-[NOTE]
-====
-These can be combined and used together.
-====
+.Procedure
 
-[[using-konflux-label]]
-== Using konflux.additional-tags image label in your Dockerfile
-
-You can specify the additional custom tags directly in your Dockerfile by using the *konflux.additional-tags* label, e.g.:
-
-[source,dockerfile]
-----
-LABEL konflux.additional-tags="tag1"
-----
-
-If you want to specify multiple tags, they have to be separated by space or a comma, e.g.:
-
-[source,dockerfile]
-----
-LABEL konflux.additional-tags="tag1 tag2"
-----
-
-[source,dockerfile]
-----
-LABEL konflux.additional-tags="tag1, tag2"
-----
-
-[[using-additional-tags-parameter]]
-== Using ADDITIONAL_TAGS parameter for apply-tags task
-You can also specify additional custom tags by using *ADDITIONAL_TAGS* array parameter for apply-tags task in your PipelineRun definition, e.g:
-
+. **Ensure `apply-tags` Task is in Your Pipeline:**
+  Your `build-pipeline.yaml` should include an `apply-tags` task, which typically runs after the `build-image-index` task.
++
 [source,yaml]
 ----
-...
-- name: apply-tags
+# In .tekton/build-pipeline.yaml
+spec:
   params:
-  - name: IMAGE
-    value: $(tasks.build-container.results.IMAGE_URL)
-  - name: ADDITIONAL_TAGS
-    value: ["tag1", "tag2"]
-  runAfter:
-  - build-container
-  taskRef:
-    params:
-    - name: name
-      value: apply-tags
-    - name: bundle
-      value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1
-    - name: kind
-      value: task
-    resolver: bundles
-...
+    # ... other params ...
+    - name: artifact-version # Assumed to be defined as a pipeline parameter
+      type: string
+      default: "main"
+  tasks:
+    # ... other tasks like init, clone-repository, build-image-index ...
+
+    - name: apply-tags
+      runAfter:
+        - build-image-index
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: apply-tags
+          - name: bundle
+            # Replace with the specific bundle and digest for the apply-tags task
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:3f89ba89cacf8547261b5ce064acce81bfe470c8ace127794d0e90aebc8c347d
+          - name: kind
+            value: task
+      params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL) # The base image URL
+        - name: ADDITIONAL_TAGS # Parameter to pass a list of tags
+          value:
+            # Tag with the artifact-version (e.g., branch name)
+            - "$(params.artifact-version)"
+            # Tag with artifact-version and commit timestamp
+            - "$(params.artifact-version)-$(tasks.clone-repository.results.commit-timestamp)"
+            # Optionally, add other static or dynamic tags
+            # - "latest" # If this is a push to the main branch
 ----
 
-The array parameter *ADDITIONAL_TAGS* can also be specified differently:
-
+. **Pass `artifact-version` from `PipelineRun`:**
+  In your `PipelineRun` files, provide the `artifact-version` parameter. This value will then be used by the `apply-tags` task within the pipeline.
++
 [source,yaml]
 ----
-...
-  - name: ADDITIONAL_TAGS
-    value:
-      - tag1
-      - tag2
-...
-----
+# In .tekton/devcontainer-playground-push.yaml (for push to main)
+spec:
+  params:
+    # ... other params ...
+    - name: artifact-version
+      value: '{{target_branch}}' # Using PaC variable for branch name
 
-[NOTE]
-====
-The provided tags can also be based on dynamic variables that are provided by Pipelines as Code, e.g.:
-
-[source,yaml]
+# In .tekton/devcontainer-playground-on-pull-request.yaml (for PRs)
+spec:
+  params:
+    # ... other params ...
+    - name: artifact-version
+      # For PRs, you might use a different versioning scheme for tags
+      value: 'pr-{{pull_request_number}}-{{source_branch}}'
 ----
-...
-  - name: ADDITIONAL_TAGS
-    value: ["pull-request-{{pull_request_number}}", "from-branch-{{source_branch}}", "{{target_branch}}"]
-...
-----
++
+*The `output-image` parameter in your `PipelineRun` (e.g., `quay.io/user/app:{{revision}}`) typically sets the primary tag, often based on the commit SHA.*
+*The `apply-tags` task then adds the `ADDITIONAL_TAGS` to this already pushed image manifest list.*
 
-To see all available dynamic variables, please see the dynamic variables section in the https://pipelinesascode.com/docs/guide/authoringprs/#dynamic-variables[Pipeline as Code documentation]
-====
+.Verification
+* After a successful pipeline run, check your image repository (e.g., Quay.io).
+* You should see the primary tag (e.g., commit SHA) and the additional custom tags (e.g., `main`, `main-20240101T120000Z`) applied to your image.
+
+.Additional Considerations
+* **Tag Uniqueness**: Ensure your tagging strategy generates unique and meaningful tags. Using timestamps or commit SHAs helps with uniqueness.
+* **`latest` Tag**: Be cautious when applying the `latest` tag. It's typically reserved for the most recent stable build from the main development branch. You might want to add a condition in your `apply-tags` task or `PipelineRun` to only apply `latest` for main branch pushes.
+* **Pipelines-as-Code Variables**: Leverage Pipelines-as-Code (PaC) variables like `{{target_branch}}`, `{{revision}}`, `{{pull_request_number}}`, `{{source_branch}}` in your `PipelineRun` files to make tag components dynamic based on the Git event.
+
+By using the `apply-tags` task with dynamically constructed tag names, you can achieve a flexible and informative tagging strategy for your container images.

--- a/modules/building/pages/labels-and-annotations.adoc
+++ b/modules/building/pages/labels-and-annotations.adoc
@@ -1,181 +1,112 @@
-= Labels and annotations
-
-Konflux allows applying some dynamic labels to images derived from properties and params of the build pipeline. The labelling is supported directly by the `LABELS` param of the *build-container* tasks. A supporting *generate-labels* task can optionally be used to produce some dynamic labels.
-
-. <<supplying-labels-and-annotations-to-the-build-container-task>>
-. <<generating-dynamic-labels-or-annotations>>
-. <<incrementing-release-label-or-annotation>>
-. <<combining-approaches>>
-
-[[supplying-labels-and-annotations-to-the-build-container-task]]
-== Supplying labels and annotations to the build-container task with the LABELS and ANNOTATIONS params
-
-You can specify additional labels and/or annotations to be applied to your image with the LABELS and ANNOTATIONS params, e.g.:
-
-[source,yaml]
-----
-tasks:
-...
-- name: build-container
-  ...
-  params:
-    - name: IMAGE
-      value: "$(params.output-image)"
-    - name: DOCKERFILE
-      value: "$(params.dockerfile)"
-    - name: HERMETIC
-      value: "$(params.hermetic)"
-    - name: LABELS <1>
-      value:
-        - from-pull-request=true
-        - hermetic-param=$(params.hermetic)
-    - name: ANNOTATIONS <1>
-      value:
-        - my-annotation=true
-        - foo=bar
-...
-----
-
-<1> The LABELS and ANNOTATIONS params accepts an array of labels and annotations to be applied to the image after it is built.
-
 [[generating-dynamic-labels-or-annotations]]
-== Generating dynamic labels or annotations
+= Generating dynamic labels or annotations
 
-You can use the *generate-labels* task to produce some dynamic labels or annotations. To do so, add the generate-labels task to the list of tasks in your pipeline, e.g.:
+You can generate dynamic labels and annotations for your container images by integrating a specialized Tekton task into your build pipeline. This task typically uses Git metadata, such as commit timestamps and branch names (or a dedicated version parameter), to create standardized OCI image labels.
 
+The `generate-labels` task (for example, `quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1`) is designed for this purpose. It can take various inputs and produce a set of labels that are then applied to your image during the build process.
+
+.Prerequisites
+* Your build pipeline (`build-pipeline.yaml` or similar) is defined and version-controlled in your repository.
+* Your pipeline includes a task for cloning the Git repository (e.g., `clone-repository` which uses `git-clone-oci-ta`) that provides results like commit timestamp and branch/revision information.
+
+.Procedure
+
+. **Add a Pipeline Parameter for Versioning (Recommended):**
+  To have consistent versioning information for both labels and tags, add a dedicated version parameter to your `build-pipeline.yaml`. This parameter will be supplied by your `PipelineRun`.
++
 [source,yaml]
 ----
-tasks:
-...
-    - name: generate-labels
-      params:
-        - name: label-templates
-          value: 
-             - "build-date=$SOURCE_DATE" <.>
-             - "short-commit=$(tasks.clone-repository.results.short-commit)"
-        - name: source-date-epoch
-          value: '$(tasks.clone-repository.results.commit-timestamp)'
-      runAfter:
-        - clone-repository
-      taskRef:
-        params:
-          - name: name
-            value: generate-labels
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:0068fe8b3c5d010daee5a922781a74cfb82251e775c260d14d9e50dd1a7aca65
-          - name: kind
-            value: task
-        resolver: bundles
-...
-----
-
-<.> The generate-labels task defines a small number of environment variables that can usefully be applied to labels and/or annotations, like $SOURCE_DATE and $SOURCE_DATE_EPOCH. See its documentation at link:https://github.com/konflux-ci/tekton-catalog/build-definitions/tree/main/task/generate-labels/0.1[task/generate-labels].
-
-The *generate-labels* task exposes a *labels* result that can be passed to the build-container task. To be useful, you need to supply the labels result from the generate-labels/generate-annotation tasks to the LABELS/ANNOTATIONS params of the build-container task, e.g.:
-
-[source,yaml]
-----
-tasks:
-...
-- name: build-container
-  ...
+# In .tekton/build-pipeline.yaml
+spec:
   params:
-    ...
-    - name: LABELS
-      value:
-      - $(tasks.generate-labels.results.labels[*])
-    - name: ANNOTATIONS
-      value:
-      - $(tasks.generate-annotations.results.labels[*])
-...
+    # ... other params ...
+    - name: artifact-version
+      description: Version to use for the container image labels and tags.
+      type: string
+      default: "main" # Or any suitable default
 ----
 
-
-[[incrementing-release-label-or-annotation]]
-=== An incrementing release label or annotation
-
-A common use case for dynamic labels or anootations is to introduce a monotonically incrementing release label.
-
-To achieve this, use either the $SOURCE_DATE or the $ACTUAL_DATE as the value for your release label, depending on your team's preference.
-
-NOTE: Use of $SOURCE_DATE will tie your release label to the timestamp of the commit that produces the build, and is more reproducible. Use of $ACTUAL_DATE will tie your release label to the timestamp at the time the build actually takes place, which yields builds that are less reproducible, but which may make more sense for your team's expectations and working model.
-
+. **Integrate the `generate-labels` Task into Your Pipeline:**
+  Add a new task to your `build-pipeline.yaml` that uses the `generate-labels` task. This task should run after the `clone-repository` task to use its results.
++
 [source,yaml]
 ----
-tasks:
-...
-    - name: generate-labels
-      params:
-        - name: label-templates
-          value: 
-             - "release=$SOURCE_DATE_EPOCH"
-        - name: source-date-epoch
-          value: '$(tasks.clone-repository.results.commit-timestamp)'
+# In .tekton/build-pipeline.yaml
+spec:
+  tasks:
+    # ... other tasks like init, clone-repository, prefetch-dependencies ...
+
+    - name: generate-image-labels
       runAfter:
         - clone-repository
+        # - prefetch-dependencies # If applicable
       taskRef:
+        resolver: bundles
         params:
           - name: name
-            value: generate-labels
+            value: generate-labels # The name of the task within the bundle
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:0068fe8b3c5d010daee5a922781a74cfb82251e775c260d14d9e50dd1a7aca65
+            # Replace with the specific bundle and digest for the generate-labels task you are using
+            value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:2eea900077190535c4dbb30e9bcc2da357bd53c408613485fb3af53484afdcbd
           - name: kind
             value: task
-        resolver: bundles
-...
-    - name: build-container
-      ...
+      params:
+        - name: label-templates # Define the labels you want to generate
+          value:
+            # Uses the $SOURCE_DATE variable provided by the task, derived from source-date-epoch
+            - "build-date=$SOURCE_DATE"
+            # Uses the $SOURCE_DATE_EPOCH variable provided by the task
+            - "release=$SOURCE_DATE_EPOCH"
+            # Uses the pipeline parameter 'artifact-version'
+            - "version=$(params.artifact-version)"
+            # Example of another common OCI label using git-clone results
+            - "org.opencontainers.image.revision=$(tasks.clone-repository.results.commit)"
+            - "org.opencontainers.image.source=$(tasks.clone-repository.results.url)"
+        - name: source-date-epoch # Provide the commit timestamp to the task
+          value: "$(tasks.clone-repository.results.commit-timestamp)"
+      # The generate-labels task typically produces a result like 'labels' (an array of strings)
+      # or 'LABELS_OCI_ARTIFACT' (an OCI artifact path) depending on the version.
+      # The example here assumes it produces a 'labels' array result.
+
+    - name: build-images # Your existing buildah task (e.g., buildah-remote-oci-ta)
       runAfter:
-        ...
-        - generate-labels
+        - generate-image-labels # Ensure labels are generated first
       params:
-        ...
-        - name: LABELS
+        # ... other buildah params ...
+        - name: LABELS # Parameter name for buildah to accept labels
           value:
-          - $(tasks.generate-labels.results.labels[*])
-...
+            - $(tasks.generate-image-labels.results.labels[*]) # Pass the generated labels
+      # ... rest of the build-images task ...
 ----
++
+*Key parameters for the `generate-labels` task:*
+** `label-templates`: An array of strings where each string is a label template.
+*** You can use variables like `$SOURCE_DATE` and `$SOURCE_DATE_EPOCH` which the task derives from the `source-date-epoch` input.
+*** You can also use Tekton parameter substitution `$(params.parameter-name)` and task result substitution `$(tasks.task-name.results.result-name)`.
+** `source-date-epoch`: This should be populated with the commit timestamp, typically from the `clone-repository` task's result (`$(tasks.clone-repository.results.commit-timestamp)`). This is used by the task to set `SOURCE_DATE_EPOCH` internally and derive `$SOURCE_DATE`.
 
-[[combining-approaches]]
-=== Combining approaches
-
-You can combine the approaches described above and supply a list of labels and/or annotations to the build-container task constructed from multiple sources.
-
+. **Pass `artifact-version` from `PipelineRun`:**
+  In your `PipelineRun` files (e.g., `devcontainer-playground-push.yaml`), pass the `artifact-version` parameter.
++
 [source,yaml]
 ----
-tasks:
-...
-    - name: build-container
-      ...
-      params:
-        ...
-        - name: LABELS
-          value:
-          - $(tasks.generate-labels.results.labels[*])
-          - "short-commit=$(tasks.clone-repository.results.short-commit)"
-        - name: ANNOTATIONS
-          value:
-          - $(tasks.generate-labels.results.labels[*])
-          - "short-commit=$(tasks.clone-repository.results.short-commit)"
-...
+# In .tekton/devcontainer-playground-push.yaml (for push to main)
+spec:
+  params:
+    # ... other params ...
+    - name: artifact-version
+      value: '{{target_branch}}' # Using PaC variable for branch name
+
+# In .tekton/devcontainer-playground-on-pull-request.yaml (for PRs)
+spec:
+  params:
+    # ... other params ...
+    - name: artifact-version
+      value: '{{target_branch}}-pr-{{pull_request_number}}' # Example for PRs
 ----
 
-You can use array indexing to supply some of the results to labels and some others to annotations:
+.Verification
+* After a successful pipeline run, inspect your image on Quay.io or using a tool like `skopeo`.
+* You should see labels like `build-date`, `release`, and `version` applied to your image, with values derived from the commit timestamp and the `artifact-version` parameter.
 
-[source,yaml]
-----
-tasks:
-...
-    - name: build-container
-      ...
-      params:
-        ...
-        - name: LABELS
-          value:
-          - $(tasks.generate-labels.results.labels[1])
-        - name: ANNOTATIONS
-          value:
-          - $(tasks.generate-labels.results.labels[2])
-          - $(tasks.generate-labels.results.labels[3])
-...
-----
+This approach ensures that your images are consistently labeled with important build and versioning information, enhancing traceability and adherence to OCI standards.

--- a/modules/patterns/nav.adoc
+++ b/modules/patterns/nav.adoc
@@ -8,3 +8,4 @@
 *** xref:maintaining-references-before-release.adoc[Maintaining valid image references before a release]
 *** xref:github-merge-queues.adoc[GitHub Merge Queues]
 *** xref:running-user-scripts-on-the-build-pipeline.adoc[Running user scripts on the build pipeline]
+*** xref:mapping-tags-to-labels.adoc[Maintaining parity between tags and labels]

--- a/modules/patterns/pages/mapping-tags-to-labels.adoc
+++ b/modules/patterns/pages/mapping-tags-to-labels.adoc
@@ -1,0 +1,110 @@
+= Pattern: Achieving Label and Tag Parity for Versioning
+
+This pattern describes how to configure your Konflux-CI build pipeline to ensure parity between a key version label (e.g., `org.opencontainers.image.version`) on your container image and a human-readable image tag. This enhances image traceability and makes it easier for users and tools to identify image versions consistently.
+
+The core idea is to use a common dynamic value, typically derived from Git metadata like the branch name or a release tag, to populate both the label and the tag.
+
+.Use Cases
+* Consistently versioning images based on the Git branch they were built from.
+* Ensuring that the version displayed in image metadata (labels) matches a discoverable image tag.
+* Simplifying image identification for users and automated deployment systems.
+
+.Prerequisites
+* A Konflux-CI build pipeline defined in your repository (e.g., `.tekton/build-pipeline.yaml`).
+* Your pipeline includes:
+    * A `clone-repository` task (e.g., using `git-clone-oci-ta`).
+    * A `generate-labels` task (e.g., using `task-generate-labels`).
+    * An `apply-tags` task (e.g., using `task-apply-tags`).
+
+.Procedure
+
+. **Define a Common Versioning Parameter in Your Pipeline:**
+   Add an `artifact-version` parameter to your `build-pipeline.yaml`. This parameter will be the source of truth for the version string.
++
+[source,yaml]
+----
+# In .tekton/build-pipeline.yaml
+spec:
+  params:
+    # ... other params ...
+    - name: artifact-version
+      description: The version string to be used for labels and tags.
+      type: string
+      default: "latest" # A sensible default
+----
+
+. **Use `artifact-version` in the `generate-labels` Task:**
+   Configure the `generate-image-labels` task in your `build-pipeline.yaml` to use the `artifact-version` parameter for the `org.opencontainers.image.version` label (or a similar version label).
++
+[source,yaml]
+----
+# In .tekton/build-pipeline.yaml (within the 'tasks' section)
+    - name: generate-image-labels
+      # ... other task configurations ...
+      params:
+        - name: label-templates
+          value:
+             # ... other labels like build-date, release ...
+             - "version=$(params.artifact-version)" # OCI version label
+             # Or, more specifically for OCI:
+             # - "org.opencontainers.image.version=$(params.artifact-version)"
+        - name: source-date-epoch
+          value: "$(tasks.clone-repository.results.commit-timestamp)"
+      # ...
+----
+
+. **Use `artifact-version` in the `apply-tags` Task:**
+   Configure the `apply-tags` task in your `build-pipeline.yaml` to create a tag based on the `artifact-version` parameter. You might also want to create other related tags, like one incorporating a timestamp or commit SHA for uniqueness.
++
+[source,yaml]
+----
+# In .tekton/build-pipeline.yaml (within the 'tasks' section)
+    - name: apply-tags
+      # ... other task configurations ...
+      params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: ADDITIONAL_TAGS
+          value:
+            # Tag directly with the artifact-version
+            - "$(params.artifact-version)"
+            # Optionally, a more unique tag incorporating the artifact-version and timestamp
+            - "$(params.artifact-version)-$(tasks.clone-repository.results.commit-timestamp)"
+            # Optionally, add 'latest' for main branch builds (can be conditional)
+            # - "latest"
+      # ...
+----
+
+. **Populate `artifact-version` Dynamically in `PipelineRun` Files:**
+   In your `PipelineRun` files (e.g., for push and PR events), use Pipelines-as-Code (PaC) variables to set the `artifact-version` parameter dynamically.
++
+[source,yaml]
+----
+# In .tekton/devcontainer-playground-push.yaml (for push to main branch)
+spec:
+  params:
+    # ... other params ...
+    - name: artifact-version
+      value: '{{target_branch}}' # e.g., results in label "version: main" and tag "main"
+
+# In .tekton/devcontainer-playground-on-pull-request.yaml (for PRs)
+spec:
+  params:
+    # ... other params ...
+    - name: artifact-version
+      # Example: "main-pr-123" or "feature-branch-pr-123"
+      value: '{{target_branch}}-pr-{{pull_request_number}}'
+----
+
+.Verification
+. After a pipeline run, inspect the built image:
+  * **Labels**: Check the image labels (e.g., using `docker inspect` or `skopeo inspect`). The `org.opencontainers.image.version` (or your chosen version label) should match the value derived from `artifact-version` (e.g., `main`).
+  * **Tags**: Check the image tags in your container registry. You should find a tag that directly matches the `artifact-version` (e.g., `main`).
+
+.Benefits of this Pattern
+* **Consistency**: Ensures the version information embedded in the image (label) matches a discoverable tag.
+* **Traceability**: Makes it easy to correlate a tagged image with its source branch or PR.
+* **Automation Friendly**: Provides a predictable versioning scheme for downstream automation and deployment tools.
+* **Clarity**: Offers a clear version identifier for users browsing the container registry.
+
+By implementing this pattern, you establish a robust and clear versioning strategy for your container images built with Konflux-CI.


### PR DESCRIPTION
this process, making it easier for others to implement similar robust build and versioning strategies:

1.  **Updated "Generating dynamic labels or annotations" (`labels-and-annotations.adoc`):**
    * Clarified the use of the `generate-labels` Tekton task.
    * Provided concrete examples of how to parameterize this task using `label-templates` and `source-date-epoch`.
    * Showed how to integrate it with pipeline parameters (e.g., a new `artifact-version` parameter) and results from other tasks (like `clone-repository` for commit timestamps) to achieve dynamic OCI labels (e.g., `build-date`, `release`, `version`).

2.  **Updated "Using custom tags" (`custom-tags.adoc`):**
    * Emphasized the role of the `apply-tags` Tekton task.
    * Demonstrated how to configure `ADDITIONAL_TAGS` by leveraging pipeline parameters (like `artifact-version`) and results from the `clone-repository` task (e.g., commit timestamp) to create dynamic, informative, and unique tags.

3.  **New "Pattern: Achieving Label and Tag Parity for Versioning" page:**
    * Introduced a new documentation pattern to guide users on establishing consistency between a key image version label (e.g., `org.opencontainers.image.version`) and a corresponding human-readable image tag.
    * Outlined the procedure of using a shared dynamic pipeline parameter (e.g., `artifact-version`) to drive both the label generation (via the `generate-labels` task) and the tag application (via the `apply-tags` task), ensuring parity.
    * Highlighted the benefits of this pattern, such as improved traceability, consistency, and automation-friendliness.

These documentation enhancements are intended to provide clearer, more actionable guidance for Konflux-CI users seeking to implement advanced image metadata and versioning practices.

Commit message and documentation content drafted with assistance from Google's Gemini.