### PR TITLE
Update the suggested snyk secret name

### DIFF
--- a/modules/building/pages/creating-secrets.adoc
+++ b/modules/building/pages/creating-secrets.adoc
@@ -12,7 +12,7 @@ Secrets can be categorized depending on when they need to be added.
 
 Sometimes to run the tasks properly, you may need to pass secrets to these tasks. Consult the documentation for these tasks to understand the proper specification of the secrets required, for example the required keys/values.
 
-NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
+NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `snyk-secret` and use the key `snyk_token` so that the snyk task in the {ProductName} pipeline will be able to access and use the token.
 
 .Procedure
 


### PR DESCRIPTION
Also mention what the key should be.

For details see the default param value here:
https://github.com/konflux-ci/build-definitions/blob/896d2925db3e75087ded6b6cffac92a3324f5fe4/task/sast-snyk-check/0.4/sast-snyk-check.yaml#L23-L25

And how the key is used:
https://github.com/konflux-ci/build-definitions/blob/896d2925db3e75087ded6b6cffac92a3324f5fe4/task/sast-snyk-check/0.4/sast-snyk-check.yaml#L139-L143

The incorrect docs were reported in the slack thread referenced by:
https://issues.redhat.com/browse/KFLUXSPRT-3153