### PR TITLE
Add a comment to not change the name of pipelines-as-code-secret secret

### DIFF
--- a/modules/building/pages/creating-secrets.adoc
+++ b/modules/building/pages/creating-secrets.adoc
@@ -141,7 +141,7 @@ kubectl create -f GL-secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pipelines-as-code-secret
+  name: pipelines-as-code-secret # Do not change this name
   namespace: <YOUR NAMESPACE>
   labels:
     appstudio.redhat.com/credentials: scm
@@ -169,7 +169,7 @@ It is also possible to have secrets for per-repository or organization access. T
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pipelines-as-code-secret
+  name: pipelines-as-code-secret # Do not change this name
   namespace: <YOUR NAMESPACE>
   labels:
     appstudio.redhat.com/credentials: scm
@@ -188,7 +188,7 @@ For a specific repository, the following secret should be created:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pipelines-as-code-secret
+  name: pipelines-as-code-secret # Do not change this name
   namespace: <YOUR NAMESPACE>
   labels:
     appstudio.redhat.com/credentials: scm
@@ -202,6 +202,7 @@ stringData:
 
 [NOTE]
 ====
+*
 * You can have multiple repositories listed under the `appstudio.redhat.com/scm.repository` annotation. Separate repository names with commas when listing them. The secret will be used for all repositories that match the specified paths.
 
 * You can also have multiple secrets with different labels and/or annotations. In order to work, at least the additional ones, need to be named with `pipeline-as-code-secret` as prefix (for example pipeline-as-code-secret-xxx).

--- a/modules/building/pages/creating-secrets.adoc
+++ b/modules/building/pages/creating-secrets.adoc
@@ -202,7 +202,6 @@ stringData:
 
 [NOTE]
 ====
-*
 * You can have multiple repositories listed under the `appstudio.redhat.com/scm.repository` annotation. Separate repository names with commas when listing them. The secret will be used for all repositories that match the specified paths.
 
 * You can also have multiple secrets with different labels and/or annotations. In order to work, at least the additional ones, need to be named with `pipeline-as-code-secret` as prefix (for example pipeline-as-code-secret-xxx).


### PR DESCRIPTION
While going through the docs and creating a secret, I updated the name of this secret to be unique for my application. Because of this no MR was generated for my gitlab project. I think this would be helpful for future users to know. 