### PR TITLE
Update mintmaker schedule

### DIFF
--- a/modules/mintmaker/pages/user.adoc
+++ b/modules/mintmaker/pages/user.adoc
@@ -233,7 +233,7 @@ Due to performance considerations, since 20 November 2024, MintMaker is configur
 |===
 |*Schedule* | *Managers*
 |Every day before 5 AM | rpm, lockFileMaintenance
-|Monday after 5 AM | dockerfile
+|Every day after 5 AM | dockerfile
 |Tuesday after 5 AM | git-submodules
 |Wednesday after 5 AM | argocd, crossplane, fleet, flux, helm-requirements, helm-values, helmfile, helmsman, helmv3, jsonnet-bundler, kubernetes, kustomize
 |Thursday after 5 AM | asdf, fvm, hermit, homebrew, osgi, pre-commit, vendir


### PR DESCRIPTION
The schedule for dockerfile manager was changed couple of months ago in https://github.com/konflux-ci/mintmaker/commit/cd1498d4603dd65ad61beef923aaa54a05e639f0

It now runs every day after 5am instead of only mondays.