### PR TITLE
fix(KONFLUX-7679): clair scan vulns missing from SCAN_OUTPUT

### DIFF
--- a/modules/testing/pages/build/index.adoc
+++ b/modules/testing/pages/build/index.adoc
@@ -26,7 +26,7 @@ The table below outlines the default build-time tests:
 |===
 |Test name |Description |Failure message
 
-|clair-scan |Scans container images for vulnerabilities using Clair, by comparing the components of container image against Clair's vulnerability databases. | Found packages with critical vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs.
+|clair-scan |Scans container images for vulnerabilities using Clair, by comparing the components of container image against Clair's vulnerability databases. | Found packages with critical vulnerabilities associated with RHSA fixes. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs.
 
 |clamav-scan |Scans the content of container images for viruses, malware, and other malicious content using ClamAV antivirus scanner. | A malware has been found.
 

--- a/modules/testing/pages/integration/standardized-outputs.adoc
+++ b/modules/testing/pages/integration/standardized-outputs.adoc
@@ -17,6 +17,8 @@ It additionaly displays found vulnerabilities, patched(RHSA fix) and unpatched o
 
 image::vulnerabilities.png[role="border" alt="Vulnerabilities"]
 
+NOTE: Scan results within Konflux will only report vulnerabilities associated with RHSAs as fixable. This can lead to inconsistencies with Clair scan results found in Quay or elsewhere.
+
 == IMAGES_PROCESSED
 
 Result[json] for recording which image digests are processed (i.e. multi-arch images). This enables the ability to validate that all of the image manifest architectures have been scanned even if a task does not support scanning all image manifests.


### PR DESCRIPTION
Clair scan detects blocking high CVE vulnerabilities that are not included in the SCAN_OUTPUT within Konflux. This PR adds a note explaining that only advisories associated with RHSAs will be reported.