### PR TITLE
chore(docs): add section on accessing assets retrieved by generic fetcher

### DIFF
--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -352,6 +352,14 @@ artifacts:
 <2> `checksum` is expected to be specified as `algorith:hash`
 <3> If no `filename` is specified, it will be derived from the URL.
 
+=== Using your prefetched generic assets
+You can find your generic prefetched assets in `/cachi2/output/deps/generic/<filename>` and access them in your `Containerfile`:
+
+[source]
+---
+RUN cp /cachi2/output/deps/generic/dependency-check.zip <location>
+---
+
 == [[netrc]]Creating the netrc secret
 
 The `prefetch-dependencies` task supports link:https://everything.curl.dev/usingcurl/netrc.html[.netrc] files for authentication.

--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -355,10 +355,10 @@ artifacts:
 === Using your prefetched generic assets
 You can find your generic prefetched assets in `/cachi2/output/deps/generic/<filename>` and access them in your `Containerfile`:
 
-[source]
----
+[source, Dockerfile]
+----
 RUN cp /cachi2/output/deps/generic/dependency-check.zip <location>
----
+----
 
 == [[netrc]]Creating the netrc secret
 

--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -357,7 +357,7 @@ You can find your generic prefetched assets in `/cachi2/output/deps/generic/<fil
 
 [source, Dockerfile]
 ----
-RUN cp /cachi2/output/deps/generic/dependency-check.zip <location>
+RUN cp /cachi2/output/deps/generic/<filename> <location>
 ----
 
 == [[netrc]]Creating the netrc secret


### PR DESCRIPTION
After spending some time looking for my assets using the generic fetcher I found them stored under `/cachi2/output/deps/generic/`. 

I figured this out through trial and error after looking at my pipeline logs and seeing this line:
```
RUN . /cachi2/cachi2.env
```

I tried combing through the docs but I may have missed it. Hopefully this saves some time for someone else too.