### PR TITLE
prefetch: Rebrand Cachi2 as Hermeto

### DIFF
--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -1,8 +1,8 @@
 = Prefetching package manager dependencies for hermetic builds
 
-In {ProductName}, you can run a hermetic build by restricting network access to the build, but without network a build can’t fetch component dependencies from a repository and might fail. To avoid that, {ProductName} can prefetch dependencies for your hermetic builds using link:https://github.com/containerbuildsystem/cachi2/blob/main/README.md[Cachi2].
+In {ProductName}, you can run a hermetic build by restricting network access to the build, but without network a build can’t fetch component dependencies from a repository and might fail. To avoid that, {ProductName} can prefetch dependencies for your hermetic builds using link:https://github.com/hermetoproject/hermeto/blob/main/README.md[Hermeto].
 
-For every build, Cachi2 generates a software bill of materials (SBOM) where all dependencies are properly declared and pinned to specific versions. Also, Cachi2 ensures that arbitrary code is never executed during the prefetch, meaning, for example, that the build doesn’t pull any undeclared dependencies. Such measures result in very accurate SBOMs and improve the build reproducibility. For more information about SBOMs, see xref:metadata:sboms.adoc[Inspecting SBOMs].
+For every build, Hermeto generates a software bill of materials (SBOM) where all dependencies are properly declared and pinned to specific versions. Also, Hermeto ensures that arbitrary code is never executed during the prefetch, meaning, for example, that the build doesn’t pull any undeclared dependencies. Such measures result in very accurate SBOMs and improve the build reproducibility. For more information about SBOMs, see xref:metadata:sboms.adoc[Inspecting SBOMs].
 
 [#available-package-managers]
 .Available package managers
@@ -37,7 +37,7 @@ For every build, Cachi2 generates a software bill of materials (SBOM) where all 
 |`N/A`
 |===
 
-NOTE: *The link:https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#what-is-this[rpm-lockfile-prototype] and the link:https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#package-managers[rpm package manager for cachi2] are not fully supported. You can use them to prefetch rpms for your hermetic builds, but the file format and technology may change in the future. If you're interested in the future of this topic, join the discussion at link:https://github.com/rpm-software-management/dnf5/issues/833[rpm-software-management/dnf5#833].
+NOTE: *The link:https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#what-is-this[rpm-lockfile-prototype] and the link:https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers[rpm package manager for Hermeto] are not fully supported. You can use them to prefetch rpms for your hermetic builds, but the file format and technology may change in the future. If you're interested in the future of this topic, join the discussion at link:https://github.com/rpm-software-management/dnf5/issues/833[rpm-software-management/dnf5#833].
 
 == Procedure
 To prefetch dependencies for a component build, complete the following steps:
@@ -97,12 +97,12 @@ You can create a netrc Secret for your pipeline as described xref:netrc[below].
 For more Go-specific `.netrc` details, see link:https://go.dev/doc/faq#git_https[the Go docs].
 
 == [[pip]]Enabling prefetch builds for `pip`
-Cachi2 supports pip by parsing of `pip` requirements files, including but not limited to, `requirements.txt` files placed in the root of your repository. By generically parsing `pip` requirements files, Cachi2 downloads the specified dependencies.
+Hermeto supports pip by parsing of `pip` requirements files, including but not limited to, `requirements.txt` files placed in the root of your repository. By generically parsing `pip` requirements files, Hermeto downloads the specified dependencies.
 
-IMPORTANT: These requirements files function as lockfiles, encompassing all transitive dependencies. You must actively pin each transitive dependency listed in the requirements file to a specific version. Check the link:https://github.com/hermetoproject/hermeto/blob/main/docs/pip.md#requirementstxt[Cachi2 documentation] for more information on how to generate the requirements file.
+IMPORTANT: These requirements files function as lockfiles, encompassing all transitive dependencies. You must actively pin each transitive dependency listed in the requirements file to a specific version. Check the link:https://github.com/hermetoproject/hermeto/blob/main/docs/pip.md#requirementstxt[Hermeto documentation] for more information on how to generate the requirements file.
 
 === Building from source
-By default, Cachi2 will only fetch the source distribution from each dependency present in the requirements file. This is to force `pip` to build every dependency from source instead of relying on pre-built wheels, bringing a greater transparency to the content that will be made available to the build.
+By default, Hermeto will only fetch the source distribution from each dependency present in the requirements file. This is to force `pip` to build every dependency from source instead of relying on pre-built wheels, bringing a greater transparency to the content that will be made available to the build.
 
 In many cases, it is necessary to include additional build dependencies that are not automatically added by `pip-compile` on the requirements file. To overcome this limitation, we recommend the use of the link:https://pybuild-deps.readthedocs.io/en/latest/index.html[pybuild-deps] tool. This tool will generate a `requirements-build.txt` that contains all the build dependencies that are needed to build the project from source.
 
@@ -123,7 +123,7 @@ spec:
 
 [NOTE]
 ====
-* By default, Cachi2 processes `requirements.txt` and `requirements-build.txt` at a specified path.
+* By default, Hermeto processes `requirements.txt` and `requirements-build.txt` at a specified path.
 ====
 
 .. Optional: In case the requirements files do not use the standard names, or in case more than a single requirements or requirements-build file is needed, you can use the following additional parameters:
@@ -138,11 +138,11 @@ spec:
             value: '{"type": "pip", "path": ".", "requirements_files": ["requirements.txt", "requirements-extras.txt", "tests/requirements.txt", "requirements_build_files": ["other-build-requirements.txt"]}'
 ----
 
-NOTE: To troubleshoot any issues you might experience when you enable prefetch builds for `pip` with source dependencies, see link:https://github.com/hermetoproject/hermeto/blob/main/docs/pip.md#troubleshooting[cachi2 documentation]
+NOTE: To troubleshoot any issues you might experience when you enable prefetch builds for `pip` with source dependencies, see link:https://github.com/hermetoproject/hermeto/blob/main/docs/pip.md#troubleshooting[Hermeto documentation]
 
 === Building by enabling the prefetching of wheels
 
-In case you don't want to build every dependency from source, Cachi2 can be configured to also fetch wheels alongside the source distributions:
+In case you don't want to build every dependency from source, Hermeto can be configured to also fetch wheels alongside the source distributions:
 
 [source,yaml]
 ----
@@ -157,8 +157,8 @@ Note that you don't need to generate a `requirements-build.txt` file as describe
 
 === [[custom-index-servers]]Prefetching `pip` dependencies from custom index servers
 
-Cachi2 supports the link:https://pip.pypa.io/en/stable/cli/pip_install/#install-index-url[--index-url] option.
-You can add this option to your `requirements.txt` file(s), instructing Cachi2 to download packages from the specified
+Hermeto supports the link:https://pip.pypa.io/en/stable/cli/pip_install/#install-index-url[--index-url] option.
+You can add this option to your `requirements.txt` file(s), instructing Hermeto to download packages from the specified
 index server. For example:
 
 [source,text]
@@ -175,18 +175,18 @@ WARNING: Do not include credentials in the index URL. If needed, provide authent
 For more pip-specific details on netrc files, review the link:https://pip.pypa.io/en/stable/topics/authentication/#netrc-support[pip documentation for netrc support].
 
 == [[npm]]Enabling prefetch builds for `npm`
-Cachi2 supports `npm` by fetching any dependencies you declare in your `package.json` and `package-lock.json` project files. The npm CLI manages the `package-lock.json` file automatically, and Cachi2 fetches any dependencies and enables your build to install them without network access.
+Hermeto supports `npm` by fetching any dependencies you declare in your `package.json` and `package-lock.json` project files. The npm CLI manages the `package-lock.json` file automatically, and Hermeto fetches any dependencies and enables your build to install them without network access.
 
 .Prerequisites
 * You have an up-to-date link:https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json[`package-lock.json`] file, newer than version 1, in your source repository. To make sure that you have the latest `package-lock.json` file, or to create a lockfile, run the link:https://docs.npmjs.com/cli/v9/commands/npm-install?v=true[`npm-install`] command. You can also look at the `lockfileVersion` attribute in your `package-lock.json` file to make sure its value is a number greater than `*1*`.
 
 == [[yarn]]Enabling prefetch builds for `yarn`
 
-Supported versions: 1.x and 3.x. Cachi2 automatically detects the version of `yarn` and fetches any dependencies you declare in your `package.json` and `yarn.lock` project files.
+Supported versions: 1.x and 3.x. Hermeto automatically detects the version of `yarn` and fetches any dependencies you declare in your `package.json` and `yarn.lock` project files.
 
 .Prerequisites
 
-* You have an up-to-date `yarn.lock` file in your source repository. To ensure you have the latest `yarn.lock` file or to create it, run the `yarn install` command. If `yarn.lock` is not up-to-date, Cachi2 will not fetch the dependencies.
+* You have an up-to-date `yarn.lock` file in your source repository. To ensure you have the latest `yarn.lock` file or to create it, run the `yarn install` command. If `yarn.lock` is not up-to-date, Hermeto will not fetch the dependencies.
 
 == [[bundler]]Enabling prefetch builds for `bundler`
 
@@ -202,7 +202,7 @@ You have a `Cargo.lock` file in your repository that lists all the dependencies.
 
 == [[rpm]]Enabling prefetch builds for `rpm`
 
-Cachi2 has a dev-preview package manager capable of fetching `rpm` dependencies. This requires the use of a pair of `rpms.in.yaml` and `rpms.lock.yaml` files to be committed to your repository. You write a `rpms.in.yaml` file and the link:https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#what-is-this[rpm-lockfile-prototype] CLI tool resolves that to produce a `rpms.lock.yaml` file. Cachi2 fetches those specific rpms and enables your build to install them without network access.
+Hermeto has a dev-preview package manager capable of fetching `rpm` dependencies. This requires the use of a pair of `rpms.in.yaml` and `rpms.lock.yaml` files to be committed to your repository. You write a `rpms.in.yaml` file and the link:https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#what-is-this[rpm-lockfile-prototype] CLI tool resolves that to produce a `rpms.lock.yaml` file. Hermeto fetches those specific rpms and enables your build to install them without network access.
 
 .Prerequisites
 * You have an up-to-date installation of link:https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#installation[rpm-lockfile-prototype].
@@ -230,7 +230,7 @@ https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#whats-th
 include::partial${context}-example-prefetch-rpm-copy-repo.adoc[]
 
 +
-NOTE: For every repository defined in your set of repo files, make sure to add the corresponding sources repo (or make sure to enable them, if they’re already present). Otherwise, the lockfile generator will not include any SRPMs in your lockfile, cachi2 won’t download any SRPMs and the source container for your build will be incomplete.
+NOTE: For every repository defined in your set of repo files, make sure to add the corresponding sources repo (or make sure to enable them, if they’re already present). Otherwise, the lockfile generator will not include any SRPMs in your lockfile, Hermeto won’t download any SRPMs and the source container for your build will be incomplete.
 
 . Run the following command to resolve your `rpms.in.yaml` file and produce a `rpms.lock.yaml` file.
 
@@ -269,16 +269,16 @@ spec:
                 - name: dev-package-managers <1>
                   value: "true"
 ----
-<1> You won't find `dev-package-managers` as a param on the `prefetch-dependencies` task. You have to add it, and set it to true. This is because Cachi2 hasn't declared stable support for rpm lockfile processing yet. It's new technology and the link:https://github.com/rpm-software-management/dnf5/issues/833[conversation] about which way forward in the dnf community is still ongoing.
+<1> You won't find `dev-package-managers` as a param on the `prefetch-dependencies` task. You have to add it, and set it to true. This is because Hermeto hasn't declared stable support for rpm lockfile processing yet. It's new technology and the link:https://github.com/rpm-software-management/dnf5/issues/833[conversation] about which way forward in the dnf community is still ongoing.
 
 NOTE: Konflux also supports prefetching RPM content which requires a Red Hat subscription. For more information see xref:./activation-keys-subscription.adoc#hermetic-network-isolated-builds[Using Red Hat activation keys to access subscription content].
 
 == [[generic]]Enabling prefetch builds for `generic fetcher`
-If you need to prefetch arbitrary files for your build, Cachi2 supports `generic fetcher` for that purpose. It uses a custom lockfile named `artifacts.lock.yaml` to achieve this. This file needs to be either commited in the source repository, or explicitly specified as an absolute path. The latter is useful in case you for some reason need the lockfile to be dynamic and committing it to the repository would be problematic. For more information on supported types of artifacts, see link:https://github.com/containerbuildsystem/cachi2/blob/main/docs/generic.md[Cachi2 documentation].
+If you need to prefetch arbitrary files for your build, Hermeto supports `generic fetcher` for that purpose. It uses a custom lockfile named `artifacts.lock.yaml` to achieve this. This file needs to be either commited in the source repository, or explicitly specified as an absolute path. The latter is useful in case you for some reason need the lockfile to be dynamic and committing it to the repository would be problematic. For more information on supported types of artifacts, see link:https://github.com/hermetoproject/hermeto/blob/main/docs/generic.md[Hermeto documentation].
 
 To prefetch dependencies for a component build, complete the following steps:
 
-. Create a `artifacts.lock.yaml` file in your git repository, with a list of files to prefetch, their checksums, and optionally their filenames. See link:https://github.com/containerbuildsystem/cachi2/blob/main/docs/generic.md[Cachi2 documentation] for complete overview of the lockfile format.
+. Create a `artifacts.lock.yaml` file in your git repository, with a list of files to prefetch, their checksums, and optionally their filenames. See link:https://github.com/hermetoproject/hermeto/blob/main/docs/generic.md[Hermeto documentation] for complete overview of the lockfile format.
 
 +
 [source,yaml]
@@ -296,11 +296,11 @@ artifacts:
 <3> If no `filename` is specified, it will be derived from the URL.
 
 === Using your prefetched generic assets
-You can find your generic prefetched assets in `/cachi2/output/deps/generic/<filename>` and access them in your `Containerfile`:
+You can find your generic prefetched assets in `/prefetch/output/deps/generic/<filename>` and access them in your `Containerfile`:
 
 [source, Dockerfile]
 ----
-RUN cp /cachi2/output/deps/generic/<filename> <location>
+RUN cp /prefetch/output/deps/generic/<filename> <location>
 ----
 
 == [[netrc]]Creating the netrc secret


### PR DESCRIPTION
The Cachi2 project has been [rebranded](https://github.com/hermetoproject/hermeto/commit/5558cba982fb0e632176fff644e3d9ab9405e153) to Hermeto, so we need to both update all the references to the previous name, and the links that pointed to the previous repository.

Should be merged after https://github.com/konflux-ci/build-definitions/pull/2407