### PR TITLE
fix: update tenant pipeline example role

### DIFF
--- a/modules/releasing/pages/tenant-release-pipelines.adoc
+++ b/modules/releasing/pages/tenant-release-pipelines.adoc
@@ -104,13 +104,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - appstudio.redhat.com
-  resources:
-  - releases/status
-  verbs:
-  - get
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Users can't bind to get/patch CR Status, so remove that from the example Role in the tenant release pipeline page.