### PR TITLE
docs(RELEASE-1352): replace `auto-release` with `block-releases` label

### DIFF
--- a/modules/end-to-end/pages/building-tekton-tasks.adoc
+++ b/modules/end-to-end/pages/building-tekton-tasks.adoc
@@ -142,7 +142,7 @@ metadata:
   name: my-tasks
   namespace: rhtap-releng-tenant
   labels:
-    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/block-releases: 'false'
     pp.engineering.redhat.com/business-unit: application-developer
 spec:
   applications:

--- a/modules/reference/pages/kube-apis/release-service.adoc
+++ b/modules/reference/pages/kube-apis/release-service.adoc
@@ -185,7 +185,7 @@ MatchedReleasePlanAdmission defines the relevant information for a matched Relea
 |===
 | Field | Description | Default | Validation
 | *`name`* __string__ | Name contains the namespaced name of the releasePlanAdmission + |  | 
-| *`active`* __boolean__ | Active indicates whether the ReleasePlanAdmission is set to auto-release or not + |  | 
+| *`active`* __boolean__ | Active indicates whether the ReleasePlanAdmission is set to block-releases or not + |  | 
 |===
 
 

--- a/modules/releasing/pages/adjusting-timeouts-resources.adoc
+++ b/modules/releasing/pages/adjusting-timeouts-resources.adoc
@@ -44,7 +44,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlanAdmission
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/block-releases: 'false'
   name: sre-production
   namespace: managed-tenant-namespace
 spec:

--- a/modules/releasing/pages/create-release-plan-admission.adoc
+++ b/modules/releasing/pages/create-release-plan-admission.adoc
@@ -26,7 +26,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlanAdmission
 metadata:
  labels:
-   release.appstudio.openshift.io/auto-release: 'true' <.>
+   release.appstudio.openshift.io/block-releases: 'false' <.>
  name: sre-production <.>
  namespace: managed-tenant-namespace <.>
 spec:
@@ -42,7 +42,7 @@ spec:
 ----
 
 +
-<.> Optional: Control whether or not this ReleasePlanAdmission is entirely disabled. If set to false, attempted releases will fail with a validation error. Defaults to true.
+<.> Optional: Control whether or not this ReleasePlanAdmission is entirely disabled. If set to true, attempted releases will fail with a validation error. Defaults to false.
 <.> The name of the release plan admission.
 <.> The Managed environment team's tenant namespace.
 <.> A list of applications that you want to enable to be deployed in the managed tenant namespace.


### PR DESCRIPTION
This commit updates the documentation to deprecate the `auto-release` label on ReleasePlanAdmissions (unchanged on ReleasePlans) with the `block-releases` label. They work the same, but opposite, so auto-release true works the same as block-releases false.