### PR TITLE
doc: Re-trigger a Release

### DIFF
--- a/modules/releasing/pages/create-release.adoc
+++ b/modules/releasing/pages/create-release.adoc
@@ -1,6 +1,8 @@
 = Creating a release
 
-A Release CR is created to submit a specific Application Snapshot to be processed according to the referenced ReleasePlan.
+A `Release` object informs Konflux that an Application's
+xref:testing:page$integration/snapshots/index.adoc[Snapshot] is ready to be released, in accordiance
+with its associated xref:create-release-plan.adoc[ReleasePlan].
 
 == Creating a `Release` object
 
@@ -17,36 +19,13 @@ The development team creates a `Release` object in the developer tenant namespac
 . Create a `Release.yaml` object locally.
 
 +
-*Example `Release.yaml` object*
+include::releasing:partial$example-manual-release.adoc[]
 
-+
-[source,yaml]
-----
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: Release
-metadata:
- name: <name-of-this-release> <.>
- namespace: dev-tenant-namespace <.>
-spec:
- releasePlan: <release-plan-name> <.>
- snapshot: <application-snapshot-name> <.>
- data: <key> <.>
-----
-
-
-+
-<.> The name of the release.
-<.> The development team's tenant namespace.
-<.> The name of the release plan specifying the pipeline to run.
-<.> The name of the application snapshot that you want to release.
-<.> Optional: An unstructured key used for providing data for the managed Pipeline.
-
-. In the development tenant namespace, apply the `Release.yaml` file and add the resource to your cluster by running the following command:
-
+. In the development tenant namespace, create the `Release` object using the `kubectl` command line:
 +
 [source,shell]
 ----
-$ kubectl apply -f Release.yaml
+$ kubectl create -f Release.yaml
 ----
 
 .*Verification*
@@ -70,36 +49,41 @@ Consult with the team managing the release pipeline before creating a new `Relea
 
 . Create a new `Release.yaml` object locally, using similar values to the original `Release` object.
 
-+
-*Example `Release.yaml` object*
-
-+
-[source,yaml]
-----
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: Release
-metadata:
- name: <new-name-of-this-release> <.>
- namespace: dev-tenant-namespace <.>
-spec:
- releasePlan: <release-plan-name> <.>
- snapshot: <application-snapshot-name> <.>
- data: <key> <.>
-----
-
-+
-<.> The name of the release. Use a different name than the original release.
-<.> The development team's tenant namespace.
-<.> The name of the release plan specifying the pipeline to run. Use the same value as the original release.
-<.> The name of the application snapshot that you want to release. Use the same value as the original release.
-<.> Optional: An unstructured key used for providing data for the managed Pipeline. Use the same value as the original release.
-
-. Apply the new `Release.yaml` object to the cluster by running the following command:
-
+.. Use `kubectl` to obtain the data of an existing `Release` object:
 +
 [source,shell]
 ----
-$ kubectl apply -f Release.yaml
+$ kubectl get release <release-name> -n <dev-tenant-namespace> -o yaml > Release.yaml
+----
+
+.. Alternatively, use https://github.com/itaysk/kubectl-neat[kubectl-neat] to remove unnecessary fields from the `Release` object:
++
+[source,shell]
+----
+$ kubectl neat get release <release-name> -n <dev-tenant-namespace> -o yaml > Release.yaml
+----
+
+. Remove the following fields from the `Release.yaml` object:
+.. `metadata` fields:
+... `annotations`
+... `creationTimestamp`
+... `finalizers`
+... `generation`
+... `name`
+... `ownerReferences`
+... `resourceVersion`
+... `uid`
+.. `status` - remove entirely or set its value to `{}`
+
+. Verify that the `Release.yaml` object is valid:
++
+include::releasing:partial$example-manual-release.adoc[]
+
+. Create the new `Release` object using the data in `Release.yaml`:
++
+[source,shell]
+----
+$ kubectl create -f Release.yaml
 ----
 
 .*Verification*

--- a/modules/releasing/pages/create-release.adoc
+++ b/modules/releasing/pages/create-release.adoc
@@ -46,7 +46,7 @@ spec:
 +
 [source,shell]
 ----
-$ kubectl apply -f Release.yaml -n dev
+$ kubectl apply -f Release.yaml
 ----
 
 .*Verification*
@@ -56,3 +56,57 @@ $ kubectl apply -f Release.yaml -n dev
 . Click on the *Releases* tab
 . See the recent releases that have been created for the application.
 . You can find a link to the release pipeline run by clicking on the name of the release that you created.
+
+== "Re-triggering" a `Release`
+
+`Release` objects create workloads with a finite lifecycle. Once created, a `Release` object's `spec` field cannot be modified.
+To "re-trigger" a release, create a new instance of the desired `Release` object using the same values in the `spec` field.
+
+
+WARNING: Creating multiple `Release` objects for the same snapshot can result in duplicate actions taken during the release process.
+Consult with the team managing the release pipeline before creating a new `Release` object for a given snapshot.
+
+.*Procedures*
+
+. Create a new `Release.yaml` object locally, using similar values to the original `Release` object.
+
++
+*Example `Release.yaml` object*
+
++
+[source,yaml]
+----
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+ name: <new-name-of-this-release> <.>
+ namespace: dev-tenant-namespace <.>
+spec:
+ releasePlan: <release-plan-name> <.>
+ snapshot: <application-snapshot-name> <.>
+ data: <key> <.>
+----
+
++
+<.> The name of the release. Use a different name than the original release.
+<.> The development team's tenant namespace.
+<.> The name of the release plan specifying the pipeline to run. Use the same value as the original release.
+<.> The name of the application snapshot that you want to release. Use the same value as the original release.
+<.> Optional: An unstructured key used for providing data for the managed Pipeline. Use the same value as the original release.
+
+. Apply the new `Release.yaml` object to the cluster by running the following command:
+
++
+[source,shell]
+----
+$ kubectl apply -f Release.yaml
+----
+
+.*Verification*
+
+. In the {ProductName} UI, select the *Applications* tab
+. Click the released application
+. Click the *Releases* tab
+. View the recent releases created for the application
+. Click the name of the release to view the results of its release pipeline
+

--- a/modules/releasing/partials/example-manual-release.adoc
+++ b/modules/releasing/partials/example-manual-release.adoc
@@ -1,0 +1,27 @@
+*Example `Release.yaml` object for a manually created release*
+
++
+[source,yaml]
+----
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+ generateName: <name-of-this-release-prefix> <.>
+ namespace: dev-tenant-namespace <.>
+ labels:
+   release.appstudio.openshift.io/automated: "false" <.>
+   release.appstudio.openshift.io/author: my-userid <.>
+spec:
+ releasePlan: <release-plan-name> <.>
+ snapshot: <application-snapshot-name> <.>
+ data: <key> <.>
+----
+
++
+<.> The prefix of the release's name. Konflux will append a unique suffix when the `Release` object is created.
+<.> The development team's tenant namespace.
+<.> Label indicating that the release was not automatically created by Konflux. This value must be set to `"false"` using quotation marks.
+<.> The ID of the user who created the release. This is required for manually created releases.
+<.> The name of the release plan specifying the pipeline to run.
+<.> The name of the application snapshot that you want to release.
+<.> Optional: An unstructured key used for providing data for the managed release Pipeline.


### PR DESCRIPTION
Document how to re-trigger a Release pipeline, which requires developers to create a new instance of a Release object using the same `spec` field values. Caution must be taken as release pipelines are not guaranteed to be idempotent.

See [KONFLUX-9511](https://issues.redhat.com/browse/KONFLUX-9511)