### PR TITLE
Add --platform to cosign CLI examples

### DIFF
--- a/modules/metadata/pages/sboms.adoc
+++ b/modules/metadata/pages/sboms.adoc
@@ -54,7 +54,7 @@ In the CLI, complete the following steps to download the SBOM for a component:
 +
 [source]
 ----
-$ cosign download sbom $IMAGE
+$ cosign download sbom --platform linux/amd64 $IMAGE
 ----
 
 +
@@ -63,7 +63,7 @@ $ cosign download sbom $IMAGE
 +
 [source]
 ----
-$ cosign download sbom $IMAGE > sbom.txt
+$ cosign download sbom --platform linux/amd64 $IMAGE > sbom.txt
 ----
 
 == Reading the SBOM


### PR DESCRIPTION
Updates the cosign CLI examples in the SBOM documentation to include the `--platform linux/amd64` option. Without this option, multi-arch images return only the image index SBOM instead of actual software packages (RPMs, Python wheels, etc).

Fixes #435