### PR TITLE
docs(STONEINTG-1215): add guide for accessing private image repositories

### DIFF
--- a/modules/building/pages/creating-secrets.adoc
+++ b/modules/building/pages/creating-secrets.adoc
@@ -37,6 +37,7 @@ NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/
 * xref:testing:build/snyk.adoc[snyk-secret]
 * xref:testing:integration/third-parties/testing-farm.adoc[testing-farm-secret]
 
+[#creating-registry-pull-secrets]
 == Creating registry pull secrets
 
 Some container builds may use parent images from registries that require authentication, for example, `registry.redhat.io`. Until these credentials have been configured, the builds will continue to fail due to the system being unable to pull the required images.

--- a/modules/testing/nav.adoc
+++ b/modules/testing/nav.adoc
@@ -9,7 +9,7 @@
 **** xref:integration/rerunning.adoc[Rerunning an integration test]
 **** xref:integration/canceling.adoc[Canceling an integration test]
 **** xref:integration/choosing-contexts.adoc[Choosing when to run certain Integration Tests]
-**** xref:integration/accessing-private-repositories.adoc[Accessing Pipelines and Tasks in Private Repositories]
+**** xref:integration/accessing-private-repositories.adoc[Accessing Private Repositories]
 **** xref:integration/periodic-integration-tests.adoc[Triggering Periodic Integration Tests]
 **** xref:integration/standardized-outputs.adoc[Standardized outputs]
 **** xref:integration/snapshots/index.adoc[Snapshots]

--- a/modules/testing/pages/integration/accessing-private-repositories.adoc
+++ b/modules/testing/pages/integration/accessing-private-repositories.adoc
@@ -1,10 +1,22 @@
-= Access Pipelines and Tasks in Private Repositories
+= Accessing Private Repositories
+
+== Accessing Images in Private Repositories
+
+The {ProductName} integration Tekton pipelines use the `konflux-integration-runner` service account.
+Tekton automatically mounts all secrets which are linked to that service accounts to the PipelineRuns and Tasks. All your component image registry secrets are automatically linked to this service account.
+
+If your integration pipeline needs to use special credentials to registries other than ones for your component images (e.g. the ones for the registry.redhat.io or similar), you will need to manually link the secret containing them to the `konflux-integration-runner` service account.
+
+1. Create the registry pull secret in your tenant namespace - consult the  xref:building:creating-secrets.adoc#creating-registry-pull-secrets[guide for pull secret creation].
+2. Manually link the new secret to the `konflux-integration-runner` service account - consult the xref:troubleshooting:registries.adoc#check-if-the-secret-is-linked-to-the-service-account[guide for linking secrets to service account].
+
+== Accessing Pipelines and Tasks in Private Git Repositories
 
 Integration Test Scenarios point to their corresponding pipeline with a link:https://tekton.dev/docs/pipelines/git-resolver/[Git Resolver]. The Git Resolver schema is inherited from Tekton and functions in the same way. Users should create an access token for their repository in link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens[Github] or link:https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html[Gitlab] then link:../building/creating-secrets.adoc#creating-source-control-secrets[store that token in a secret] in their namespace.
 
 Once this is done, the Resolver should be updated with the fields `token` and `tokenKey`, which provide the name of the secret and the key within the `data` section of that secret in which the access token is stored.
 
-== Example of Resolver in IntegrationTestScenario
+=== Example of Resolver in IntegrationTestScenario
 
 [source,yaml]
 .its.yaml
@@ -39,7 +51,7 @@ spec:
         value: ${SECRET_KEY}
 ----
 
-== Example of Resolver in Pipeline
+=== Example of Resolver in Pipeline
 
 This is an example of how tasks in private repos can be accessed with the Git Resolver using the same method as above.
 
@@ -56,9 +68,9 @@ spec:
     Demonstrates the use of Git Resolvers to access tasks in private repos
   tasks:
     - name: parse-metadata
-        taskRef:
-          resolver: git
-          params:
+      taskRef:
+        resolver: git
+        params:
             - name: org
               value: konflux-ci
             - name: repo
@@ -73,7 +85,7 @@ spec:
               value: ${SECRET_NAME}
             - name: tokenKey
               value: ${SECRET_KEY}
-        params:
-          - name: SNAPSHOT
-            value: $(params.SNAPSHOT)
+      params:
+      - name: SNAPSHOT
+        value: $(params.SNAPSHOT)
 ----


### PR DESCRIPTION
Guide for accessing image pull secrets in integration pipelines
* Add information about `konflux-integration-runner` service account
* Add information about linking image pull secrets to service account

Signed-off-by: dirgim <kpavic@redhat.com>