### PR TITLE
update the location of the multi-arch example

### DIFF
--- a/modules/reference/pages/sample-repositories.adoc
+++ b/modules/reference/pages/sample-repositories.adoc
@@ -7,7 +7,7 @@ either use these as reference or you can fork them and try to onboard the reposi
 
 This repository demonstrates the configuration for a simple multi-architecture build.
 
-https://github.com/konflux-ci/multi-arch-konflux-sample
+https://github.com/konflux-ci/multi-arch-konflux-example
 
 == OLM operator
 


### PR DESCRIPTION
- The original sample repo is now being used for testing purposes and is locked down as a private repo.
- The new repo is a copy of the sample one.