### PR TITLE
fix cosign installation URL

### DIFF
--- a/modules/metadata/pages/discover.adoc
+++ b/modules/metadata/pages/discover.adoc
@@ -2,7 +2,7 @@
 
 .Prerequisites
 
-* Install the link:https://docs.sigstore.dev/cosign/installation/[Cosign] CLI tool.
+* Install the link:https://docs.sigstore.dev/cosign/system_config/installation/[Cosign] CLI tool.
 
 * Install the link:https://stedolan.github.io/jq/download/[jq] CLI tool.
 

--- a/modules/metadata/pages/sboms.adoc
+++ b/modules/metadata/pages/sboms.adoc
@@ -35,7 +35,7 @@ The SBOM is unsigned so there is no way to verify whether it has been tampered w
 
 .Prerequisites
 
-* Install the link:https://docs.sigstore.dev/cosign/installation/[Cosign] CLI tool.
+* Install the link:https://docs.sigstore.dev/cosign/system_config/installation/[Cosign] CLI tool.
 
 * Install the link:https://stedolan.github.io/jq/download/[jq] CLI tool.
 


### PR DESCRIPTION
The upstream cosign devs have moved the install instructions to a new
location. Update the link to reflect this change.
