### PR TITLE
fix(automerge): example custom schedule

### DIFF
--- a/modules/building/pages/component-nudges.adoc
+++ b/modules/building/pages/component-nudges.adoc
@@ -183,8 +183,9 @@ data:
   commitMessageSuffix: "custom namespace suffix message"
   fileMatch: ".*Dockerfile.*, .*.yaml, .*Containerfile.*"
   ignoreTests: "true"
-  platformAutomerge: "true"
   gitLabIgnoreApprovals: "true"
-  automergeSchedule: "* 22-23,0-4 * * *; * * * * 0,6"
+  platformAutomerge: "true"
+  # eventually set `platformAutomerge: "false"` and configure your own schedule
+  # automergeSchedule: "* 22-23,0-4 * * *; * * * * 0,6"
   labels: "customLabel1, customLabel2"
 --


### PR DESCRIPTION
automergeSchedule is ignored when platformAutomerge: "true", state it explicitly in the example.

Resolves: #482