### PR TITLE
feat(STONEINTG-1370): update kube-api docs

### DIFF
--- a/modules/reference/nav.adoc
+++ b/modules/reference/nav.adoc
@@ -4,7 +4,7 @@
 *** xref:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-application[Application]
 *** xref:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-component[Component]
 *** xref:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-snapshot[Snapshot]
-*** xref:kube-apis/enterprise-contract.adoc#k8s-api-github-com-conforma-crds-api-v1alpha1-enterprisecontractpolicy[EnterpriseContractPolicy]
+*** xref:kube-apis/conforma.adoc#k8s-api-github-com-conforma-crds-api-v1alpha1-enterprisecontractpolicy[EnterpriseContractPolicy]
 *** xref:kube-apis/image-controller.adoc#k8s-api-github-com-konflux-ci-image-controller-api-v1alpha1-imagerepository[ImageRepository]
 *** xref:kube-apis/integration-service.adoc#k8s-api-github-com-konflux-ci-integration-service-api-v1alpha1-integrationtestscenario[IntegrationTestScenario]
 *** xref:kube-apis/release-service.adoc#k8s-api-github-com-konflux-ci-release-service-api-v1alpha1-release[Release]

--- a/modules/reference/pages/kube-apis/application-api.adoc
+++ b/modules/reference/pages/kube-apis/application-api.adoc
@@ -30,7 +30,7 @@ Package v1alpha1 contains API Schema definitions for the appstudio v1alpha1 API 
 
 
 
-Application is the Schema for the applications API.  For a detailed description with examples, refer to <a href="https://github.com/redhat-appstudio/book/blob/main/book/HAS/hybrid-application-service-api.md"> Hybrid Application Service Kube API </a>
+Application is the Schema for the applications API. For description, refer to xref:kube-apis/application-api.adoc[Application API Reference] Hybrid Application Service Kube API </a>
 
 
 
@@ -162,7 +162,7 @@ ApplicationStatus defines the observed state of Application
 
 
 
-Component is the Schema for the components API.    For a detailed description with examples, refer to <a href="https://github.com/redhat-appstudio/book/blob/main/book/HAS/hybrid-application-service-api.md"> Hybrid Application Service Kube API </a>
+Component is the Schema for the components API. For description, refer to xref:kube-apis/application-api.adoc[Application API Reference] Hybrid Application Service Kube API </a>
 
 
 
@@ -230,7 +230,7 @@ ComponentDetectionMap is a map containing all the components and their detected 
 
 
 
-ComponentDetectionQuery is the Schema for the componentdetectionqueries API.    For a detailed description with examples, refer to <a href="https://github.com/redhat-appstudio/book/blob/main/book/HAS/hybrid-application-service-api.md"> Hybrid Application Service Kube API </a>
+ComponentDetectionQuery is the Schema for the componentdetectionqueries API. For description, refer to xref:kube-apis/application-api.adoc[Application API Reference] Hybrid Application Service Kube API </a>
 
 
 

--- a/modules/reference/pages/kube-apis/conforma.adoc
+++ b/modules/reference/pages/kube-apis/conforma.adoc
@@ -2,7 +2,7 @@
 :anchor_prefix: k8s-api
 
 [id="reference"]
-== Conforma (formerly Enterprise Contract) API Reference
+== Conforma API Reference
 
 .Packages
 - xref:{anchor_prefix}-appstudio-redhat-com-v1alpha1[$$appstudio.redhat.com/v1alpha1$$]
@@ -67,7 +67,7 @@ DEPRECATED: Use the config for a policy source instead.
 the success of the outcome. + |  | 
 | *`include`* __string array__ | Include set of policy inclusions that are added to the policy evaluation. +
 These override excluded rules. + |  | 
-| *`collections`* __string array__ | Collections set of predefined rules.  DEPRECATED: Collections can be listed in include +
+| *`collections`* __string array__ | Collections set of predefined rules. DEPRECATED: Collections can be listed in include +
 with the "@" prefix. + |  | 
 |===
 
@@ -243,12 +243,13 @@ VolatileCriteria includes or excludes a policy rule with effective dates as an o
 | *`effectiveUntil`* __string__ |  |  | Format: date-time +
 
 | *`imageRef`* __string__ | DEPRECATED: Use ImageDigest instead +
-ImageRef is used to specify an image by its digest. + |  | Pattern: `^sha256:[a-fA-F0-9]\{64\}$` +
+ImageRef is used to specify an image by its digest. + |  | Pattern: `^sha256:[a-fA-F0-9]64$` +
 
-| *`imageDigest`* __string__ | ImageDigest is used to specify an image by its digest. + |  | Pattern: `^sha256:[a-fA-F0-9]\{64\}$` +
+| *`imageDigest`* __string__ | ImageDigest is used to specify an image by its digest. + |  | Pattern: `^sha256:[a-fA-F0-9]64$` +
 
-| *`imageUrl`* __string__ | ImageUrl is used to specify an image by its URL without a tag. + |  | Pattern: `^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$` +
+| *`imageUrl`* __string__ | ImageUrl is used to specify an image by its URL without a tag. + |  | Pattern: `^[a-z0-9][a-z0-9.-]\*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$` +
 
+| *`reference`* __string__ | Reference is used to include a link to related information such as a Jira issue URL. + |  | 
 |===
 
 

--- a/modules/reference/pages/kube-apis/index.adoc
+++ b/modules/reference/pages/kube-apis/index.adoc
@@ -5,7 +5,7 @@ Below are the Kubernetes API extensions added by Konflux.
 * xref:reference:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-application[Application]
 * xref:reference:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-component[Component]
 * xref:reference:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-snapshot[Snapshot]
-* xref:reference:kube-apis/enterprise-contract.adoc#k8s-api-github-com-conforma-crds-api-v1alpha1-enterprisecontractpolicy[EnterpriseContractPolicy]
+* xref:reference:kube-apis/conforma.adoc#k8s-api-github-com-conforma-crds-api-v1alpha1-enterprisecontractpolicy[EnterpriseContractPolicy]
 * xref:reference:kube-apis/image-controller.adoc#k8s-api-github-com-konflux-ci-image-controller-api-v1alpha1-imagerepository[ImageRepository]
 * xref:reference:kube-apis/integration-service.adoc#k8s-api-github-com-konflux-ci-integration-service-api-v1alpha1-integrationtestscenario[IntegrationTestScenario]
 * xref:reference:kube-apis/release-service.adoc#k8s-api-github-com-konflux-ci-release-service-api-v1alpha1-release[Release]

--- a/modules/reference/pages/kube-apis/integration-service.adoc
+++ b/modules/reference/pages/kube-apis/integration-service.adoc
@@ -60,7 +60,7 @@ Component/Application GitOps repository resources.
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`env`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1alpha1-envvarpair[$$EnvVarPair$$] array__ | Env is an array of standard environment variables + |  | 
+| *`env`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1alpha1-envvarpair[$$EnvVarPair$$] array__ | Environment is an array of standard environment variables + |  | 
 | *`target`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1alpha1-environmenttarget[$$EnvironmentTarget$$]__ | Target is used to reference a DeploymentTargetClaim for a target Environment. +
 The Environment controller uses the referenced DeploymentTargetClaim to access its bounded +
 DeploymentTarget with cluster credential secret. + |  | 
@@ -342,7 +342,7 @@ Component/Application GitOps repository resources.
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`env`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1beta1-envvarpair[$$EnvVarPair$$] array__ | Env is an array of standard environment variables + |  | 
+| *`env`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1beta1-envvarpair[$$EnvVarPair$$] array__ | Environment is an array of standard environment variables + |  | 
 | *`target`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1beta1-environmenttarget[$$EnvironmentTarget$$]__ | Target is used to reference a DeploymentTargetClaim for a target Environment. +
 The Environment controller uses the referenced DeploymentTargetClaim to access its bounded +
 DeploymentTarget with cluster credential secret. + |  | 
@@ -636,7 +636,8 @@ Package v1beta2 contains API Schema definitions for the appstudio v1beta2 API gr
 
 
 
-IntegrationTestScenario is the Schema for the integrationtestscenarios API
+IntegrationTestScenario is the Schema for the integrationtestscenarios API, holds a definiton for integration test with specified attributes like pipeline reference,
+application and environment. It is a test template triggered after successful creation of a snapshot.
 
 
 
@@ -662,7 +663,7 @@ IntegrationTestScenario is the Schema for the integrationtestscenarios API
 
 
 
-IntegrationTestScenarioList contains a list of IntegrationTestScenario
+IntegrationTestScenarioList contains a list of IntegrationTestScenarios
 
 
 
@@ -700,7 +701,8 @@ IntegrationTestScenarioSpec defines the desired state of IntegrationScenario
 
 | *`resolverRef`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1beta2-resolverref[$$ResolverRef$$]__ | Tekton Resolver where to store the Tekton resolverRef trigger Tekton pipeline used to refer to a Pipeline or Task in a remote location like a git repo. + |  | 
 | *`params`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1beta2-pipelineparameter[$$PipelineParameter$$] array__ | Params to pass to the pipeline + |  | 
-| *`contexts`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1beta2-testcontext[$$TestContext$$] array__ | Contexts where this IntegrationTestScenario can be applied + |  | 
+| *`contexts`* __xref:{anchor_prefix}-github-com-konflux-ci-integration-service-api-v1beta2-testcontext[$$TestContext$$] array__ | Contexts where this IntegrationTestScenario can be applied, for specific component for example + |  | 
+| *`dependents`* __string array__ | List of IntegrationTestScenario which are blocked by the successful completion of this IntegrationTestScenario + |  | 
 |===
 
 
@@ -709,7 +711,7 @@ IntegrationTestScenarioSpec defines the desired state of IntegrationScenario
 
 
 
-IntegrationTestScenarioStatus defines the observed state of IntegrationTestScenario
+IntegrationTestScenarioStatus defines the observed state of IntegrationTestScenario described by conditions
 
 
 
@@ -730,7 +732,7 @@ IntegrationTestScenarioStatus defines the observed state of IntegrationTestScena
 
 
 
-PipelineParameter contains the name and values of a Tekton Pipeline parameter
+PipelineParameter contains the name and values of a Tekton Pipeline parameter, used by IntegrationTestScenarioSpec Params
 
 
 
@@ -792,6 +794,9 @@ Tekton Resolver where to store the Tekton resolverRef trigger Tekton pipeline us
 referenced Tekton resource. Example entries might include +
 "repo" or "path" but the set of params ultimately depends on +
 the chosen resolver. + |  | 
+| *`resourceKind`* __string__ | ResourceKind defines the kind of resource being resolved. It can either +
+be "pipeline" or "pipelinerun" but defaults to "pipeline" if no value is +
+set + |  | 
 |===
 
 
@@ -800,7 +805,7 @@ the chosen resolver. + |  |
 
 
 
-TestContext contains the name and values of a Test context
+TestContext contains the name and values of a Test context, used by IntegrationTestScenarioSpec Contexts
 
 
 

--- a/modules/reference/pages/kube-apis/mintmaker.adoc
+++ b/modules/reference/pages/kube-apis/mintmaker.adoc
@@ -24,7 +24,7 @@ Package v1alpha1 contains API Schema definitions for the appstudio v1alpha1 API 
 
 
 
-
+ApplicationSpec scopes MintMaker to specific Components within a single Konflux Application.
 
 
 
@@ -36,7 +36,8 @@ Package v1alpha1 contains API Schema definitions for the appstudio v1alpha1 API 
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`application`* __string__ | Specifies the name of the application for which to run Mintmaker. +
+| *`application`* __string__ | Specifies the name of the Konflux application for which to run Mintmaker. +
+For more details see <a href="https://github.com/konflux-ci/architecture/blob/main/architecture/core/hybrid-application-service.md">Konflux Application Service</a>. +
 Required. + |  | Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
 
 | *`components`* __xref:{anchor_prefix}-github-com-konflux-ci-mintmaker-api-v1alpha1-component[$$Component$$] array__ | Specifies the list of components of an application for which to run MintMaker. +
@@ -51,7 +52,7 @@ Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
 
 _Underlying type:_ _string_
 
-
+Component represents a Component name within a Konflux Application.
 
 .Validation:
 - MaxLength: 63
@@ -69,7 +70,19 @@ _Underlying type:_ _string_
 
 
 
-DependencyUpdateCheck is the Schema for the dependencyupdatechecks API
+DependencyUpdateCheck is the root CRD that triggers mintmaker to Konflux Components for dependency updates.
+How the controller uses this CRD:
+- Only CRs created in the MintMaker namespace (see `MintMakerNamespaceName`) are processed.
+- When a CR is created, the controller discovers Konflux Components to scan:
+  - By default: all `appstudio.redhat.com/v1alpha1, Kind=Component` across the cluster
+  - Or: a filtered subset when `spec.namespaces` is provided
+  - For each unique repository+branch across those Components, the controller generates
+    one Tekton `PipelineRun` that scans the repository for dependency updates using Renovate.
+
+
+Annotations:
+  - `mintmaker.appstudio.redhat.com/processed`: set by the controller when the
+    DependencyUpdateCheck is processed, to avoid reprocessing the same CR.
 
 
 
@@ -117,7 +130,9 @@ DependencyUpdateCheckList contains a list of DependencyUpdateCheck
 
 
 
-DependencyUpdateCheckSpec defines the desired state of DependencyUpdateCheck
+DependencyUpdateCheckSpec filters which Konflux Components will be scanned.
+If `namespaces` is empty, MintMaker scans all Components discoverable to the controller.
+If provided, MintMaker only scans Components that match the namespace/application/component filters.
 
 
 
@@ -155,7 +170,7 @@ DependencyUpdateCheckStatus defines the observed state of DependencyUpdateCheck
 
 
 
-
+NamespaceSpec scopes MintMaker to specific Applications within a Kubernetes namespace.
 
 
 
@@ -167,10 +182,10 @@ DependencyUpdateCheckStatus defines the observed state of DependencyUpdateCheck
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`namespace`* __string__ | Specifies the name of the namespace for which to run Mintmaker. +
+| *`namespace`* __string__ | Specifies the name of the Kubernetes namespace for which to run Mintmaker. +
 Required. + |  | Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
 
-| *`applications`* __xref:{anchor_prefix}-github-com-konflux-ci-mintmaker-api-v1alpha1-applicationspec[$$ApplicationSpec$$] array__ | Specifies the list of applications in a namespace for which to run MintMaker. +
+| *`applications`* __xref:{anchor_prefix}-github-com-konflux-ci-mintmaker-api-v1alpha1-applicationspec[$$ApplicationSpec$$] array__ | Specifies the list of Konflux applications in a namespace for which to run MintMaker. +
 If omitted, MintMaker will run for all namespace's applications. + |  | 
 |===
 

--- a/modules/reference/pages/kube-apis/project-controller.adoc
+++ b/modules/reference/pages/kube-apis/project-controller.adoc
@@ -28,7 +28,8 @@ Package v1beta1 contains API Schema definitions for the projctl v1beta1 API grou
 
 
 
-Project is the Schema for the projects API
+Project represents a Konflux project for organizing related development streams.
+No custom labels or annotations on Project alter controller behavior.
 
 
 
@@ -53,7 +54,8 @@ Project is the Schema for the projects API
 
 
 
-ProjectDevelopmentStream is the Schema for the projectdevelopmentstreams API
+ProjectDevelopmentStream represents an independent stream of development.
+No custom labels or annotations on the object alter controller behavior.
 
 
 
@@ -102,6 +104,7 @@ ProjectDevelopmentStreamList contains a list of ProjectDevelopmentStream
 
 
 ProjectDevelopmentStreamSpec defines the desired state of ProjectDevelopmentStream
+A development stream typically represents a version or environment branch.
 
 
 
@@ -126,6 +129,7 @@ ProjectDevelopmentStream + |  |
 
 ProjectDevelopmentStreamSpecTemplateRef defines which optional template is
 associated with this ProjectDevelopmentStream and how to apply it
+The template must exist in the same namespace as the stream.
 
 
 
@@ -149,6 +153,7 @@ associated with this ProjectDevelopmentStream and how to apply it
 
 Provide a value for a variable specified in an associated
 ProjectDevelopmentStreamTemplate
+Use values to customize generated resources per development stream.
 
 
 
@@ -171,6 +176,9 @@ ProjectDevelopmentStreamTemplate
 
 
 ProjectDevelopmentStreamStatus defines the observed state of ProjectDevelopmentStream
+Conditions include:
+- TemplateApplied (reasons: Success, TemplateNotFound, VariableError, ResourceError, ProcessingError)
+- TemplateGenerated (reasons: Success, TemplateError, VariableValidationFailed, ResourceValidationFailed)
 
 
 
@@ -192,7 +200,9 @@ Known .status.conditions.type are: "TemplateApplied", and "TemplateGenerated" + 
 
 
 
-ProjectDevelopmentStreamTemplate is the Schema for the projectdevelopmentstreamtemplates API
+ProjectDevelopmentStreamTemplate defines a reusable set of resources
+that a ProjectDevelopmentStream can instantiate using variable values.
+No custom labels or annotations on the object alter controller behavior.
 
 
 
@@ -241,6 +251,7 @@ ProjectDevelopmentStreamTemplateList contains a list of ProjectDevelopmentStream
 
 ProjectDevelopmentStreamTemplateSpec defines the resources to be generated
 using a ProjectDevelopmentStreamTemplate
+Resources can interpolate variables (e.g., {{.version}}) and functions like hyphenize.
 
 
 
@@ -268,6 +279,7 @@ variables using the Go-text/template syntax + |  |
 
 
 Settings for a variable to be used to customize the template results
+Variables are processed in order; later defaults can reference earlier variables.
 
 
 
@@ -314,7 +326,8 @@ ProjectList contains a list of Project
 
 
 
-ProjectSpec defines the desired state of Project
+ProjectSpec defines the desired state of a Project.
+A Project groups related development streams and provides metadata for display.
 
 
 

--- a/modules/reference/pages/kube-apis/release-service.adoc
+++ b/modules/reference/pages/kube-apis/release-service.adoc
@@ -94,6 +94,7 @@ ServiceAccount to be used in the PipelineRun.
 |===
 | Field | Description | Default | Validation
 | *`items`* __xref:{anchor_prefix}-github-com-konflux-ci-release-service-api-v1alpha1-collectoritem[$$CollectorItem$$] array__ | Items is the list of Collectors to be executed as part of the release workflow + |  | 
+| *`secrets`* __string array__ | Secrets is the list of secrets to be used in the Collector's Pipeline + |  | 
 | *`serviceAccountName`* __string__ | ServiceAccountName is the ServiceAccount to use during the execution of the Collectors Pipeline + |  | Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
 
 |===
@@ -185,7 +186,7 @@ MatchedReleasePlanAdmission defines the relevant information for a matched Relea
 |===
 | Field | Description | Default | Validation
 | *`name`* __string__ | Name contains the namespaced name of the releasePlanAdmission + |  | 
-| *`active`* __boolean__ | Active indicates whether the ReleasePlanAdmission is set to block-releases or not + |  | 
+| *`active`* __boolean__ | Active indicates whether the ReleasePlanAdmission is set to auto-release or not + |  | 
 |===
 
 
@@ -232,9 +233,8 @@ PipelineInfo defines the observed state of a release pipeline processing.
 | *`completionTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#time-v1-meta[$$Time$$]__ | CompletionTime is the time when the Release processing was completed + |  | 
 | *`pipelineRun`* __string__ | PipelineRun contains the namespaced name of the managed Release PipelineRun executed as part of this release + |  | Pattern: `^[a-z0-9]([-a-z0-9]\*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
 
-| *`roleBinding`* __string__ | RoleBinding contains the namespaced name of the roleBinding created for the managed Release PipelineRun +
-executed as part of this release + |  | Pattern: `^[a-z0-9]([-a-z0-9]\*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
-
+| *`roleBindings`* __xref:{anchor_prefix}-github-com-konflux-ci-release-service-api-v1alpha1-rolebindingtype[$$RoleBindingType$$]__ | RoleBindings defines the roleBindings for accessing resources during the Release +
+PipelineRun executed as part of this release. + |  | 
 | *`startTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#time-v1-meta[$$Time$$]__ | StartTime is the time when the Release processing started + |  | 
 |===
 
@@ -636,6 +636,32 @@ ReleaseStatus defines the observed state of Release.
 | *`completionTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#time-v1-meta[$$Time$$]__ | CompletionTime is the time when a Release was completed + |  | 
 | *`startTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#time-v1-meta[$$Time$$]__ | StartTime is the time when a Release started + |  | 
 | *`expirationTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#time-v1-meta[$$Time$$]__ | ExpirationTime is the time when a Release can be purged + |  | 
+|===
+
+
+[id="{anchor_prefix}-github-com-konflux-ci-release-service-api-v1alpha1-rolebindingtype"]
+==== RoleBindingType
+
+
+
+RoleBindingType defines the state of roleBindings for resource access within the Release pipelineRun.
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-konflux-ci-release-service-api-v1alpha1-pipelineinfo[$$PipelineInfo$$]
+****
+
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+| *`tenantRoleBinding`* __string__ | TenantRoleBinding contains the namespaced name of the roleBinding created for accessing resources within the tenant namespace. + |  | Pattern: `^[a-z0-9]([-a-z0-9]\*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
+
+| *`managedRoleBinding`* __string__ | ManagedRoleBinding contains the namespaced name of the roleBinding created for accessing resources within the managed namespace. + |  | Pattern: `^[a-z0-9]([-a-z0-9]\*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
+
+| *`secretRoleBinding`* __string__ | SecretRoleBinding contains the namespaced name of the roleBinding created for accessing secrets within the namespace. + |  | Pattern: `^[a-z0-9]([-a-z0-9]\*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
+
 |===
 
 


### PR DESCRIPTION
Integration-service updated their integrationTestScenario api documentation, in order to reflect it in konflux.docs we need to run `api-gen` to update those values. Together with integration service, other services were updated as `api-gen` fetches api objects from various places.