### PR TITLE
mintmaker: clarify component-level scope of disable annotation

### DIFF
--- a/modules/mintmaker/pages/user.adoc
+++ b/modules/mintmaker/pages/user.adoc
@@ -384,6 +384,8 @@ Example:
 ----
 oc -n <namespace> annotate component/<component-name> mintmaker.appstudio.redhat.com/disabled=true
 ----
+NOTE: This annotation disables MintMaker at the component level (a specific repository and branch combination).
+When a repository or branch has multiple components, you must annotate each component individually to disable MintMaker for the entire branch or repository.
 
 === How to limit the number of PRs/MRs
 


### PR DESCRIPTION
Add a note explaining that the mintmaker.appstudio.redhat.com/disabled annotation must be applied to each component individually when multiple components share the same repository or branch. This clarifies that disabling mintmaker for a branch or repository requires annotating all corresponding components.