### PR TITLE
fix(gemini): remove rule about code syntax

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -4,7 +4,6 @@
 * Focus on good stylistic and correct english grammar
 * Use imperative mood language
 * AsciiDoc format is used in the documentation
-* Use ONLY AsciiDoc syntax: ==== for headers, |=== for tables, ---- for code blocks
 * Do NOT mix markdown and AsciiDoc syntax
 * Maintain proper table structures with matching |=== opening and closing
 * Keep all cross-references (xref) intact and properly formatted


### PR DESCRIPTION
it was causing false positives comments about using `----` code block, while code block was already there