### PR TITLE
Mark vanguard as owners of project controller pattern

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,9 @@
 /modules/metadata/pages/sboms.adoc  			@konflux-ci/the-collective
 /modules/metadata/partials/sbom*.adoc  			@konflux-ci/the-collective
 
+# Vanguard
+/modules/patterns/pages/managing-multiple-versions.adoc			@konflux-ci/vanguard
+
 # find a team to own these
 
 /modules/metadata/	@ralphbean @arewm


### PR DESCRIPTION
Noticed during review of https://github.com/konflux-ci/docs/pull/505