### PR TITLE
Manually update task bundles using pmt

### DIFF
--- a/modules/troubleshooting/pages/builds.adoc
+++ b/modules/troubleshooting/pages/builds.adoc
@@ -88,11 +88,19 @@ cat <<'EOF' > update-tekton-task-bundles.sh
 #!/bin/bash
 
 # Use this script to update the Tekton Task Bundle references used in a Pipeline or a PipelineRun.
-# update-tekton-task-bundles.sh .tekton/*.yaml
+#
+# Update bundles in a specific YAML file:
+# update-tekton-task-bundles.sh .tekton/build-pipeline.yaml
+#
+# Update bundles in all YAML files under .tekton/
+# update-tekton-task-bundles.sh
 
 set -euo pipefail
 
 FILES=$@
+if [[ -z "$FILES" ]]; then
+    FILES=$(find .tekton/ -name "*.yaml")
+fi
 
 # Determine the flavor of yq and adjust yq commands accordingly
 if [ -z "$(yq --version | grep mikefarah)" ]; then
@@ -113,6 +121,8 @@ OLD_REFS="$(\
     sort -u \
 )"
 
+arg_new_bundles=()
+
 # Find updates for image references
 for old_ref in ${OLD_REFS}; do
     repo_tag="${old_ref%@*}"
@@ -120,10 +130,20 @@ for old_ref in ${OLD_REFS}; do
     new_ref="${repo_tag}@${new_digest}"
     [[ $new_ref == $old_ref ]] && continue
     echo "New digest found! $new_ref"
-    for file in $FILES; do
-        pmt migrate --new-bundle "$new_ref" --pipeline-file "$file" <1>
-    done
+    arg_new_bundles+=(--new-bundle "$new_ref")
 done
+
+if [[ ${#arg_new_bundles[@]} = 0 ]]; then
+    echo "All bundles are up-to-date."
+    exit
+fi
+
+arg_pipeline_files=()
+for file in $FILES; do
+    arg_pipeline_files+=(--pipeline-file "$file")
+done
+
+pmt migrate ${arg_new_bundles[@]} ${arg_pipeline_files[@]}  <1>
 EOF
 
 chmod +x update-tekton-task-bundles.sh


### PR DESCRIPTION
STONEBLD-3592

The pmt-migrate command now handles both bundle updates and task migrations when available. This functionality is implemented for STONEBLD-3592.