### PR TITLE
Make the CODEOWNERS for this doc match the task

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,11 @@
 # Vanguard
 /modules/patterns/pages/managing-multiple-versions.adoc			@konflux-ci/vanguard
 
+
+# Here, make the CODEOWNERS here match the same CODEOWNERS line in
+# build-definitions as for task/run-script-oci-ta
+/modules/patterns/pages/running-user-scripts-on-the-build-pipeline.adoc	@Zokormazo @arewm @konflux-ci/build-maintainers
+
 # find a team to own these
 
 /modules/metadata/	@ralphbean @arewm


### PR DESCRIPTION
I noticed this when I saw that @tkdchen's PR at https://github.com/konflux-ci/docs/pull/517 had been pending review for a while.