### PR TITLE
docs: add UI onboarding guides for GitHub, GitLab, and Forgejo compon…

### DIFF
--- a/modules/building/nav.adoc
+++ b/modules/building/nav.adoc
@@ -1,9 +1,9 @@
 * xref:index.adoc[Building]
 ** Getting started
 *** xref:creating.adoc[Creating applications and components]
-**** xref:creating-github.adoc[Onboarding a component from GitHub with the CLI]
-**** xref:creating-gitlab.adoc[Onboarding a component from GitLab with the CLI]
-**** xref:creating-forgejo.adoc[Onboarding a component from Forgejo with the CLI]
+**** xref:creating-github.adoc[Onboarding a component from GitHub]
+**** xref:creating-gitlab.adoc[Onboarding a component from GitLab]
+**** xref:creating-forgejo.adoc[Onboarding a component from Forgejo]
 *** xref:deleting.adoc[Deleting applications and components]
 *** xref:running.adoc[Running build pipelines]
 ** Build configuration

--- a/modules/building/pages/creating-forgejo.adoc
+++ b/modules/building/pages/creating-forgejo.adoc
@@ -1,6 +1,6 @@
-= Onboarding a component from Forgejo with the CLI
+= Onboarding a component from Forgejo
 
-Create components from Forgejo repositories using `kubectl`.
+Create components from Forgejo repositories using the {ProductName} UI or `kubectl`.
 
 [WARNING]
 ====
@@ -47,7 +47,45 @@ Before onboarding a component from Forgejo, you must create a source control sec
 * The access token is scoped to the permissions you selected, so ensure you have granted sufficient permissions for {ProductName} to interact with your repository.
 ====
 
-== Creating a component
+[[creating-a-component-with-the-ui]]
+== Creating a component with the UI
+
+.Prerequisites:
+
+* xref:installing:enabling-builds.adoc[Enabled] build pipelines for your instance of {ProductName}.
+* xref:installing:enabling-builds.adoc#enable-image-controller[Enabled] image controller for your instance of {ProductName}.
+* An existing application in your namespace.
+
+.Procedure
+
+. In the {ProductName} UI, go to the *Applications* page.
+. Click on the name of the application that you want to add a component to.
+. Click on *Actions* and *Add component*.
+. If a source control secret does not already exist for the repository or the host, click *Add secret* in the *Build time secret* section at the bottom of the page and complete the following fields:
+  .. Set *Secret type* to `Source secret`.
+  .. Enter a unique name for the secret (for example, `pac-forgejo`).
+  .. Set *Authentication type* to `Basic authentication`.
+  .. Enter the hostname of your Forgejo instance in the *Host* field (for example, `codeberg.org`).
+  .. (Optional) Enter the repository path in the *Repository* field to scope the secret to a specific repository (for example, `org/project`). Leave empty to apply the secret to all repositories on the host.
+  .. Leave the *Username* field empty.
+  .. Enter your access token in the *Password* field. See <<creating-a-forgejo-access-token-and-secret>> for instructions on how to acquire an access token.
+  .. Click *Create*.
+. Enter the URL for the git repository.
+. (Optional) After clicking out of the repository URL, expand the *Show advanced Git options*.
+  .. Enter the branch name to the *Git reference* dialog.
+  .. Enter the path to the context directory if the build context is contained somewhere other than the repository root.
+  .. Select `forgejo` from the *Git provider annotation* drop-down menu.
+  .. Enter the base URL of your Forgejo instance in the *Git url annotation* field (for example, `https://codeberg.org`).
+. Enter the path to the Dockerfile within the git repository. This will be the path within the context directory.
+. (Optional) Change the component name if desired.
+. (Optional) Click on the *Pipeline* drop down box and select the desired pipeline to configure your component with.
+. (Optional) Click on *Add secret* to add any additional secrets needed for the component build. See xref:building:secrets/index.adoc[creating secrets] for more information.
+. Click *Add component*.
+
++
+NOTE: When a component is immediately removed after creation, it might result in an orphaned ImageRepository whose ownership was not yet assigned to the component. When trying to create a component again with the same name, the UI will report an error that the ImageRepository already exists. To resolve this, remove the ImageRepository manually from OCP.
+
+== Creating a component with the CLI
 
 . Create a `Component.yaml` file locally.
 

--- a/modules/building/pages/creating-github.adoc
+++ b/modules/building/pages/creating-github.adoc
@@ -1,15 +1,48 @@
-= Onboarding a component from GitHub with the CLI
+= Onboarding a component from GitHub
 
-Create components from GitHub repositories using `kubectl`.
+Create components from GitHub repositories using the {ProductName} UI or `kubectl`.
 
-== Prerequisites
+NOTE: Before onboarding a component from GitHub, install the {ProductName} GitHub App on your organization or repository. The GitHub App name is provided by your {ProductName} administrators.
+
+[[creating-a-component-with-the-ui]]
+== Creating a component with the UI
+
+.Prerequisites:
+
+* xref:installing:enabling-builds.adoc[Enabled] build pipelines for your instance of {ProductName}.
+* xref:installing:enabling-builds.adoc#enable-image-controller[Enabled] image controller for your instance of {ProductName}.
+* An existing application in your namespace.
+* The {ProductName} GitHub App installed on your organization or repository.
+
+.Procedure
+
+. In the {ProductName} UI, go to the *Applications* page.
+. Click on the name of the application that you want to add a component to.
+. Click on *Actions* and *Add component*.
+. Enter the URL for the git repository.
+. (Optional) After clicking out of the repository URL, expand the *Show advanced Git options*.
+  .. Enter the branch name to the *Git reference* dialog.
+  .. Enter the path to the context directory if the build context is contained somewhere other than the repository root.
+. Enter the path to the Dockerfile within the git repository. This will be the path within the context directory.
+. (Optional) Change the component name if desired.
+. (Optional) Click on the *Pipeline* drop down box and select the desired pipeline to configure your component with.
+. (Optional) Click on *Add secret* to add any additional secrets needed for the component build. See xref:building:secrets/index.adoc[creating secrets] for more information.
+. Click *Add component*.
+
++
+NOTE: When a component is immediately removed after creation, it might result in an orphaned ImageRepository whose ownership was not yet assigned to the component. When trying to create a component again with the same name, the UI will report an error that the ImageRepository already exists. To resolve this, remove the ImageRepository manually from OCP.
+
+== Creating a component with the CLI
+
+.Prerequisites:
 
 * xref:installing:enabling-builds.adoc[Enabled] build pipelines for your instance of {ProductName}.
 * link:https://kubernetes.io/docs/tasks/tools/[kubectl] CLI tool
 * You have completed the steps listed in the xref:ROOT:getting-started.adoc#getting-started-with-the-cli[Getting started with the CLI] page.
 * An existing application in your namespace.
+* The {ProductName} GitHub App installed on your organization or repository.
 
-== Procedures
+.Procedure
 
 . Create a `Component.yaml` file locally.
 

--- a/modules/building/pages/creating-gitlab.adoc
+++ b/modules/building/pages/creating-gitlab.adoc
@@ -1,6 +1,6 @@
-= Onboarding a component from GitLab with the CLI
+= Onboarding a component from GitLab
 
-Create components from GitLab repositories using `kubectl`.
+Create components from GitLab repositories using the {ProductName} UI or `kubectl`.
 
 == Prerequisites
 
@@ -37,7 +37,45 @@ NOTE: If you do not see this option, ask a user with repository maintainer permi
 * If your GitLab project uses restrictive link:https://docs.gitlab.com/ee/user/project/repository/push_rules.html[push rules] to verify users, {ProductName} may fail to push commits to your repository.
 ====
 
-== Creating a component
+[[creating-a-component-with-the-ui]]
+== Creating a component with the UI
+
+.Prerequisites:
+
+* xref:installing:enabling-builds.adoc[Enabled] build pipelines for your instance of {ProductName}.
+* xref:installing:enabling-builds.adoc#enable-image-controller[Enabled] image controller for your instance of {ProductName}.
+* An existing application in your namespace.
+
+.Procedure
+
+. In the {ProductName} UI, go to the *Applications* page.
+. Click on the name of the application that you want to add a component to.
+. Click on *Actions* and *Add component*.
+. If a source control secret does not already exist for the repository or the host, click *Add secret* in the *Build time secret* section at the bottom of the page and complete the following fields:
+  .. Set *Secret type* to `Source secret`.
+  .. Enter a unique name for the secret (for example, `pac-gitlab`).
+  .. Set *Authentication type* to `Basic authentication`.
+  .. Enter the hostname of your GitLab instance in the *Host* field (for example, `gitlab.com`).
+  .. (Optional) Enter the repository path in the *Repository* field to scope the secret to a specific repository (for example, `org/project`). Leave empty to apply the secret to all repositories on the host.
+  .. Leave the *Username* field empty.
+  .. Enter your access token in the *Password* field. See <<creating-a-gitlab-access-token-and-secret>> for instructions on how to acquire an access token.
+  .. Click *Create*.
+. Enter the URL for the git repository.
+. (Optional) After clicking out of the repository URL, expand the *Show advanced Git options*.
+  .. Enter the branch name to the *Git reference* dialog.
+  .. Enter the path to the context directory if the build context is contained somewhere other than the repository root.
+  .. Select `gitlab` from the *Git provider annotation* drop-down menu.
+  .. Enter the base URL of your GitLab instance in the *Git url annotation* field (for example, `https://gitlab.com`).
+. Enter the path to the Dockerfile within the git repository. This will be the path within the context directory.
+. (Optional) Change the component name if desired.
+. (Optional) Click on the *Pipeline* drop down box and select the desired pipeline to configure your component with.
+. (Optional) Click on *Add secret* to add any additional secrets needed for the component build. See xref:building:secrets/index.adoc[creating secrets] for more information.
+. Click *Add component*.
+
++
+NOTE: When a component is immediately removed after creation, it might result in an orphaned ImageRepository whose ownership was not yet assigned to the component. When trying to create a component again with the same name, the UI will report an error that the ImageRepository already exists. To resolve this, remove the ImageRepository manually from OCP.
+
+== Creating a component with the CLI
 
 . Create a `Component.yaml` file locally.
 

--- a/modules/building/pages/creating.adoc
+++ b/modules/building/pages/creating.adoc
@@ -58,31 +58,6 @@ NOTE: You can create additional applications by adding their custom resource con
 
 A component is an individual part of an application that contains source code and a build configuration.
 
-Before onboarding a component to {ProductName}, ensure that the instance has appropriate access to the git repository. This means either installing your organization's {ProductName} GitHub App on the source code repository or xref:building:secrets/creating-scm-secrets.adoc[creating a secret] to enable access to a GitLab or Forgejo repository.
-
-=== Supported source control providers
-
-{ProductName} supports onboarding components from the following source control providers:
-
-[cols="1,2,3",options="header"]
-|===
-|Provider
-|Authentication Method
-|Requirements
-
-|GitHub
-|GitHub App installation
-|Install the {ProductName} GitHub App on your organization or repository
-
-|GitLab
-|Source control secret
-|xref:building:creating-gitlab.adoc#creating-a-gitlab-access-token-and-secret[Create a source control secret] before onboarding
-
-|Forgejo
-|Source control secret
-|xref:building:creating-forgejo.adoc#creating-a-forgejo-access-token-and-secret[Create a source control secret] before onboarding
-|===
-
 NOTE: Component names must be unique in a namespace, even when components are used in different applications.
 
 CAUTION: {ProductName} pushes directly to branches in your onboarded repositories. In order to properly onboard, ensure
@@ -90,34 +65,22 @@ that no rules prevent pushes to the branch patterns *`konflux-*`* and *`konflux/
 
 === With the UI
 
-.Prerequisites:
+{ProductName} supports onboarding components from multiple source control providers using the UI. Choose the guide for your provider:
 
-* xref:installing:enabling-builds.adoc[Enabled] build pipelines for your instance of {ProductName}.
-* xref:installing:enabling-builds.adoc#enable-image-controller[Enabled] image controller for your instance of {ProductName}.
-* An existing application in your namespace.
+[cols="1,3",options="header"]
+|===
+|Provider
+|Guide
 
-.*Procedures*
+|GitHub
+|xref:building:creating-github.adoc#creating-a-component-with-the-ui[Onboarding a component from GitHub with the UI]
 
-. In the {ProductName} UI, go to the *Applications* page.
-. Click on the name of the application that you want to add a component to.
-. Click on *Actions* and *Add component*.
-+
-NOTE: For *GitLab* and *Forgejo* providers, create a source control secret before creating the component. See xref:building:creating-gitlab.adoc#creating-a-gitlab-access-token-and-secret[GitLab] or xref:building:creating-forgejo.adoc#creating-a-forgejo-access-token-and-secret[Forgejo] access token guides.
-  . Enter the URL for the git repository.
-  . (Optional) After clicking out of the repository URL, expand the *Show advanced Git options*.
-    . Enter the branch name to the *Git reference* dialogue.
-    . Enter the path to the context directory if the build context is contained somewhere other than the repository root.
-  . Enter the path to the Dockerfile within the git repository. This will be the path within the context directory.
-  . (Optional) Change the component name if desired.
-  . (Optional) Click on the *Pipeline* drop down box and select the desired pipeline to configure your component with.
-  . (Optional) Click on *Add secret* to add a secret which will be needed for the component build. See xref:building:secrets/index.adoc[creating secrets] for more information.
-. Click *Add component*.
+|GitLab
+|xref:building:creating-gitlab.adoc#creating-a-component-with-the-ui[Onboarding a component from GitLab with the UI]
 
-+
-NOTE: When Component is immediately removed after creation it might result with orphaned ImageRepository which ownership
-wasn't yet assigned to the Component and when trying to create Component again with the same name UI will
-complain with error that ImageRepository already exists, solution is to remove manually ImageRepository
-from OCP.
+|Forgejo
+|xref:building:creating-forgejo.adoc#creating-a-component-with-the-ui[Onboarding a component from Forgejo with the UI]
+|===
 
 === With the CLI
 
@@ -129,13 +92,13 @@ from OCP.
 |Guide
 
 |GitHub
-|xref:building:creating-github.adoc[Onboarding a component from GitHub with the CLI]
+|xref:building:creating-github.adoc#creating-a-component-with-the-cli[Onboarding a component from GitHub with the CLI]
 
 |GitLab
-|xref:building:creating-gitlab.adoc[Onboarding a component from GitLab with the CLI] (requires xref:building:secrets/creating-scm-secrets.adoc[source control secrets])
+|xref:building:creating-gitlab.adoc#creating-a-component-with-the-cli[Onboarding a component from GitLab with the CLI]
 
 |Forgejo
-|xref:building:creating-forgejo.adoc[Onboarding a component from Forgejo with the CLI] (requires xref:building:secrets/creating-scm-secrets.adoc[source control secrets])
+|xref:building:creating-forgejo.adoc#creating-a-component-with-the-cli[Onboarding a component from Forgejo with the CLI]
 |===
 
 == Using different from default image repository


### PR DESCRIPTION
…ents

Split component onboarding docs into separate per-provider guides covering both UI and CLI, improving UX by removing the need for users to mentally skip provider-specific steps that don't apply to them. This mirrors the existing CLI section structure and makes each provider's guide self-contained and directly linkable.

- Add UI procedures to creating-github, creating-gitlab, creating-forgejo
- Include inline source secret creation steps for GitLab/Forgejo UI flow
- Document Git provider annotation and Git url annotation fields
- Simplify creating.adoc to link to per-provider guides via tables
- Remove redundant secret requirement mentions from the main page
- Add GitHub App installation prerequisite note for GitHub provider