### PR TITLE
Include partials to extend the prefetching-dependencies docs

### DIFF
--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -35,6 +35,8 @@ For every build, Hermeto generates a software bill of materials (SBOM) where all
 
 |xref:generic[generic]
 |`N/A`
+
+include::partial${context}-prefetch-experimental-rows.adoc[]
 |===
 
 == Procedure
@@ -372,6 +374,8 @@ Refer to the link:https://hermetoproject.github.io/hermeto/generic/#example[gene
 
 include::partial${context}-prefetch-hermeto-note.adoc[]
 ====
+
+include::partial${context}-prefetch-experimental.adoc[]
 
 == [[netrc]]Creating the netrc secret
 

--- a/modules/building/partials/konflux-prefetch-experimental-rows.adoc
+++ b/modules/building/partials/konflux-prefetch-experimental-rows.adoc
@@ -1,0 +1,2 @@
+// This partial is referenced by building/pages/prefetching-dependencies.adoc
+// Add below table rows to reference experimental Hermeto package managers.

--- a/modules/building/partials/konflux-prefetch-experimental.adoc
+++ b/modules/building/partials/konflux-prefetch-experimental.adoc
@@ -1,0 +1,2 @@
+// This partial is referenced by building/pages/prefetching-dependencies.adoc
+// Add below sections to explain the use of experimental Hermeto package managers.


### PR DESCRIPTION
Hermeto has a workflow in which new package manager support is added in form of experimental backends. These partials are meant to be used as a means to provide information for such backends before they reach a stable version.