### PR TITLE
feat(STONEINTG-1524): Document WARNING test outcome and 'note' field

### DIFF
--- a/modules/testing/pages/integration/adding.adoc
+++ b/modules/testing/pages/integration/adding.adoc
@@ -48,4 +48,6 @@ When the new build is finished:
 
 . xref:./editing.adoc[Edit the integration test] if it is not properly configured.
 
-The test results will also be available from the PR in GitHub or the MR in GitLab. In GitHub, the test results can be viewed in the *Checks* tab. In GitLab, the test results will show up in the *Pipelines* tab. In both cases, comments will be created once the integration tests finish running, showing the results of the most recent test run.
+The test results will also be available from the PR in GitHub or the MR in GitLab. In GitHub, the test results can be viewed in the *Checks* tab. In GitLab, the test results will show up in the *Pipelines* tab. In both cases, comments will be created once the integration tests finish running, showing the results of the most recent test run. The report table includes a *Note* column that displays the contents of the `note` field from each task's TEST_OUTPUT, when present.
+
+If a test finishes with a `WARNING` outcome, the integration service reports it as passed with a distinct status to each git provider. On GitHub, check runs display with a `neutral` conclusion and a "Warning" title. On GitLab, the commit status is reported as `success`. On Forgejo, the commit status is reported as `warning`. In all cases, the summary message indicates the test "has warning(s)" rather than a standard pass.

--- a/modules/testing/pages/integration/creating.adoc
+++ b/modules/testing/pages/integration/creating.adoc
@@ -324,13 +324,18 @@ When the new build is finished, complete the following steps in the {ProductName
 
 == Standardized test result
 
-In examples above, you can see TEST_OUTPUT result being used as standardized output. This is a tekton result test outcome in json format.
+In the examples above, you can see the TEST_OUTPUT result being used as standardized output. This is a Tekton result test outcome in JSON format.
+
+The `result` field supports the following values: `SUCCESS`, `FAILURE`, `ERROR`, and `WARNING`. A `WARNING` result indicates the test passed but produced non-critical warnings. The integration service treats warnings as passed, but reports them with distinct messaging to git providers so that users can review the warnings.
+
+The `note` field is optional and can contain additional context about the test outcome. When present, the note is displayed in the git provider report table alongside the test status.
+
 TEST_OUTPUT example:
 ----
 {"result":"SUCCESS","timestamp":"2025-04-02T01:45:00+00:00","note":"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.","namespace":"default","successes":1,"failures":0,"warnings":0}
 ----
 
-For more information about standardized tekton results in konflux, please visit
-link: https://konflux-ci.dev/architecture/ADR/0030-tekton-results-naming-convention.html[Tekton Results Naming Convention]
+For more information about standardized Tekton results in {ProductName}, visit
+link:https://konflux-ci.dev/architecture/ADR/0030-tekton-results-naming-convention.html[Tekton Results Naming Convention]
 or
 xref:testing:integration/standardized-outputs.adoc[Standardized outputs]

--- a/modules/testing/pages/integration/standardized-outputs.adoc
+++ b/modules/testing/pages/integration/standardized-outputs.adoc
@@ -6,9 +6,13 @@ containing all results from the task.
 
 == TEST_OUTPUT
 
-Each tekton task in build pipelinerun provides TEST_OUTPUT result [json] that sumarizes its outcome. It's then being evaluated by Conforma team whether the product can be released or not.
+Each Tekton task in a build PipelineRun provides a TEST_OUTPUT result (JSON) that summarizes its outcome. It is then evaluated by the Conforma team to determine whether the product can be released.
 
-This result type can be also used in integration test pipelines and tasks where it can be parsed by the integration service when deciding the outcome of the integration test. This means you can use it to fail individual test tasks by emitting this result instead of failing the task and stopping the entire pipeline. With this approach it is possible to run multiple tests within the same pipeline and pass or fail them individually.
+This result type can also be used in integration test pipelines and tasks where it can be parsed by the integration service when deciding the outcome of the integration test. This means you can use it to fail individual test tasks by emitting this result instead of failing the task and stopping the entire pipeline. With this approach it is possible to run multiple tests within the same pipeline and pass or fail them individually.
+
+The `result` field in TEST_OUTPUT supports the following values: `SUCCESS`, `FAILURE`, `ERROR`, and `WARNING`. If at least one task produces a `WARNING` outcome and no tasks produce `FAILURE` or `ERROR`, the overall integration test outcome is `WARNING`. This outcome is treated as passed, but the integration service reports it with a "passed with warnings" message to git providers.
+
+The `note` field is an optional string that provides additional context about the test outcome. When present, the note is displayed in the *Note* column of the test report table posted to git provider pull or merge requests.
 
 == SCAN_OUTPUT
 


### PR DESCRIPTION
The integration service now supports a WARNING test outcome and surfaces the note field from TEST_OUTPUT in git provider reports.

- Document WARNING as a valid TEST_OUTPUT result value and its behavior as a non-blocking pass with distinct reporting.
- Document the note field and its display in the report table
- Describe how warnings map to each git provider status (GitHub: neutral, GitLab: success, Forgejo: warning)