### PR TITLE
Fix typo in ReleasePlan description

### DIFF
--- a/modules/releasing/pages/create-release-plan.adoc
+++ b/modules/releasing/pages/create-release-plan.adoc
@@ -1,6 +1,6 @@
 = Creating a release plan
 
-A ReleasePlan (RP) CR is created for a specific Application. It defines the the process to release a specific Application Snapshot in a target tenant namespace, whether automatic releases are enabled, as well as additional data to pass to a corresponding RPA.
+A ReleasePlan (RP) CR is created for a specific Application. It defines the process to release a specific Application Snapshot in a target tenant namespace, whether automatic releases are enabled, as well as additional data to pass to a corresponding RPA.
 
 == Creating a `ReleasePlan` object
 


### PR DESCRIPTION
Removed duplicate 'the' in the description of ReleasePlan.