### PR TITLE
replace appstudio-utils with task-runner

### DIFF
--- a/modules/building/pages/scheduled-builds.adoc
+++ b/modules/building/pages/scheduled-builds.adoc
@@ -113,7 +113,8 @@ spec:
         spec:
           containers:
             - name: trigger-scheduled-build
-              image: 'quay.io/konflux-ci/appstudio-utils:latest'
+              # Find the latest version at https://quay.io/repository/konflux-ci/task-runner?tab=tags
+              image: 'quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f'
               command:
                 - /bin/bash
                 - '-c'

--- a/modules/testing/pages/integration/periodic-integration-tests.adoc
+++ b/modules/testing/pages/integration/periodic-integration-tests.adoc
@@ -91,8 +91,8 @@ spec:
         spec:
           containers:
             - name: trigger-e2e-scenario
-              image: 'quay.io/konflux-ci/appstudio-utils:latest'
-              imagePullPolicy: Always
+              # Find the latest version at https://quay.io/repository/konflux-ci/task-runner?tab=tags
+              image: 'quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f'
               command:
                 - /bin/bash
                 - '-c'


### PR DESCRIPTION
`appstudio-utils` will be decommissioned soon, the replacement is the `task-runner`.
I've pinned a specific version, since there is no `latest` tag for the `task-runner` and there is (as of now) no plan on adding it.

`task-runner` contains all the tools necessary and they not require root access privileges.