### PR TITLE
Add llms.txt generation and :description: attributes to all pages

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -8,4 +8,5 @@
 * Maintain proper table structures with matching |=== opening and closing
 * Keep all cross-references (xref) intact and properly formatted
 * Includes from partials must contain {context} template variable
+* Every page MUST include a `:description:` document attribute immediately after the `= Title` line. The description should be a single sentence summarizing the page's purpose. It is used for HTML meta tags and for generating `llms.txt`.
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -56,6 +56,9 @@ jobs:
       - name: Generate website
         run: npm ci && npm run build
 
+      - name: Generate llms.txt
+        run: npm run generate-llms-txt
+
       - name: Store pull request data
         run: |
           mkdir pull_request

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,6 +66,9 @@ jobs:
       - name: Generate website
         run: npm ci && npm run build
 
+      - name: Generate llms.txt
+        run: npm run generate-llms-txt
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -17,6 +17,10 @@ BasedOnStyles = RedHat, Konflux
 # Git Links are okay.
 RedHat.GitLinks=NO
 
+[modules/reference/pages/llms-txt.adoc]
+
+Konflux.UpstreamLinks = NO
+
 [modules/ROOT/pages/reference/kube-apis/*.adoc]
 
 # For now, only enforce the Konflux style for generated API docs.

--- a/hack/generate-llms-txt.sh
+++ b/hack/generate-llms-txt.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Generates llms.txt for the Konflux documentation.
+# Scans the Antora content tree (AsciiDoc modules) and produces a structured
+# index following the llms.txt specification (https://llmstxt.org/).
+#
+# Usage:
+#   generate-llms-txt.sh <output_file>
+#
+# Arguments:
+#   output_file  - Output path for llms.txt (e.g., public/llms.txt)
+#
+# Environment:
+#   RAW_GITHUB_BASE - Base URL for raw AsciiDoc links
+#                     (default: https://raw.githubusercontent.com/konflux-ci/docs/main/modules)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULES_DIR="$ROOT_DIR/modules"
+OUTPUT_FILE="${1:?Usage: generate-llms-txt.sh <output_file>}"
+RAW_BASE="${RAW_GITHUB_BASE:-https://raw.githubusercontent.com/konflux-ci/docs/main/modules}"
+
+[[ "$OUTPUT_FILE" != /* ]] && OUTPUT_FILE="$ROOT_DIR/$OUTPUT_FILE"
+
+PRODUCT_NAME="Konflux"
+
+subst_attrs() {
+  sed "s/{ProductName}/${PRODUCT_NAME}/g; s/{ProductShortName}//g"
+}
+
+# Extract the :description: attribute from an AsciiDoc document header.
+get_description() {
+  local adoc_file="$1"
+  sed -n '/^:description:[[:space:]]*/{ s/^:description:[[:space:]]*//; p; q; }' "$adoc_file" \
+    | subst_attrs
+}
+
+# Read nav file paths from antora.yml in declaration order.
+get_nav_files() {
+  sed -n '/^nav:/,/^[^ -]/p' "$ROOT_DIR/antora.yml" \
+    | grep '\.adoc' \
+    | sed 's/^[[:space:]]*-[[:space:]]*//'
+}
+
+# Section heading override for the ROOT module.
+section_heading_for() {
+  local module="$1" line="$2"
+  case "$module" in
+    ROOT) echo "Docs" ;;
+    *)
+      if [[ "$line" =~ xref:[^[]+\[([^\]]+)\] ]]; then
+        echo "${BASH_REMATCH[1]}" | subst_attrs
+      else
+        echo "${line#\* }" | subst_attrs
+      fi
+      ;;
+  esac
+}
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+{
+cat << 'HEADER'
+# Konflux Documentation
+
+> Konflux is an open-source platform for building, testing, and releasing applications with enterprise-grade software supply chain security. It automates CI/CD pipelines using Tekton, provides SLSA Build Level 3 provenance, integrates policy-based compliance checks with Conforma, and manages releases across environments — all on Kubernetes.
+
+- Documentation site: https://konflux-ci.dev/docs/
+- Source code: https://github.com/konflux-ci/docs
+- Operator and installation docs: https://konflux-ci.dev/konflux-ci/docs/
+HEADER
+
+while IFS= read -r nav_path; do
+  nav_file="$ROOT_DIR/$nav_path"
+  [ -f "$nav_file" ] || continue
+
+  module=$(echo "$nav_path" | sed 's|modules/\([^/]*\)/nav\.adoc|\1|')
+
+  section_emitted=false
+  declare -A seen_files=()
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    [[ "$line" =~ ^include:: ]] && continue
+    [[ "$line" =~ ^// ]] && continue
+
+    stars="${line%%[^*]*}"
+    level=${#stars}
+
+    # First top-level entry → section heading
+    if [ "$level" -eq 1 ] && [ "$section_emitted" = false ]; then
+      heading=$(section_heading_for "$module" "$line")
+      printf '\n## %s\n\n' "$heading"
+      section_emitted=true
+      # Plain-text headings (no xref) have no page to link
+      if [[ ! "$line" =~ xref: ]]; then
+        continue
+      fi
+    fi
+
+    # Process xref entries
+    if [[ "$line" =~ xref:([^[]+)\[([^\]]+)\] ]]; then
+      target="${BASH_REMATCH[1]}"
+      label=$(echo "${BASH_REMATCH[2]}" | subst_attrs)
+
+      # Skip fragment-only links (anchors within an already-linked page)
+      [[ "$target" == *"#"* ]] && continue
+
+      # Resolve cross-module references (e.g. end-to-end:building-olm.adoc)
+      resolved_module="$module"
+      file_target="$target"
+      if [[ "$file_target" =~ ^([a-zA-Z_-]+):(.+)$ ]]; then
+        resolved_module="${BASH_REMATCH[1]}"
+        file_target="${BASH_REMATCH[2]}"
+      fi
+      file_target="${file_target#page\$}"
+
+      # Deduplicate within the same module nav
+      file_key="${resolved_module}/${file_target}"
+      if [ -n "${seen_files[$file_key]+x}" ]; then
+        continue
+      fi
+      seen_files[$file_key]=1
+
+      adoc_file="$MODULES_DIR/$resolved_module/pages/$file_target"
+      [ -f "$adoc_file" ] || continue
+
+      url="${RAW_BASE}/${resolved_module}/pages/${file_target}"
+      desc=$(get_description "$adoc_file")
+
+      if [ -n "$desc" ]; then
+        printf -- '- [%s](%s): %s\n' "$label" "$url" "$desc"
+      else
+        printf -- '- [%s](%s)\n' "$label" "$url"
+      fi
+    fi
+  done < "$nav_file"
+
+  unset seen_files
+done < <(get_nav_files)
+
+} > "$OUTPUT_FILE"
+
+echo "Generated llms.txt → $OUTPUT_FILE"

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,4 +1,5 @@
 = Getting started with {ProductName}
+:description: Key concepts: namespaces, pipelines, and tenant workflows on Konflux.
 
 Adopting new platforms is always challenging.
 While we aim to make use of industry-standard terminology and processes, we may need to introduce additional concepts.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = Why {ProductName}?
+:description: Konflux's value proposition and key platform capabilities.
 
 include::partial${context}-why-konflux.adoc[]
 

--- a/modules/ROOT/pages/share-with-community.adoc
+++ b/modules/ROOT/pages/share-with-community.adoc
@@ -1,4 +1,5 @@
 = Share Tenant with the Community
+:description: Granting all authenticated Konflux users read-only access to your tenant namespace.
 
 As a tenant admin, you may want to give visibility on your project to the Konflux users outside your team.
 

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -1,4 +1,5 @@
 = Accessing private image repositories
+:description: RBAC and proxy URLs for pulling private tenant component images.
 
 When the image repository visibility is set to `private` (the default), you need to authenticate before you can pull images. Konflux provides an RBAC image proxy that controls access based on your permissions.
 

--- a/modules/building/pages/accessing-pulp-content.adoc
+++ b/modules/building/pages/accessing-pulp-content.adoc
@@ -1,4 +1,5 @@
 = Accessing Pulp content
+:description: Accessing uploaded artifacts through the Pulp API and credentials.
 
 When your namespace has a Pulp controller configured (via a xref:building:pulp-access.adoc[PulpAccessRequest]), access to uploaded content requires the credentials and configuration that the controller provides.
 

--- a/modules/building/pages/activation-keys-subscription.adoc
+++ b/modules/building/pages/activation-keys-subscription.adoc
@@ -1,4 +1,5 @@
 = Using Red Hat activation keys to access subscription content
+:description: Using Red Hat activation-key secrets for entitled RPM builds.
 
 Most Red Hat software requires a subscription to access. Activation keys are the preferred method for using Red Hat subscriptions with Konflux builds and are supported by the all types of container builds, including hermetic builds using the prefetch-dependencies task.
 

--- a/modules/building/pages/apply-task-migrations.adoc
+++ b/modules/building/pages/apply-task-migrations.adoc
@@ -1,4 +1,5 @@
 = Applying task migrations
+:description: Running the pipeline migration tool when automatic task migrations are needed.
 
 {ProductName} allows task owners to write migrations to bring pipeline changes
 to users. Generally, users do not need to care about how the migrations are

--- a/modules/building/pages/build-binaries.adoc
+++ b/modules/building/pages/build-binaries.adoc
@@ -1,4 +1,5 @@
 = Building Binaries in {ProductName}
+:description: Containerfile patterns for compiling binaries as Konflux-managed artifacts.
 
 This guide provides guidelines on how to build binaries within {ProductName}.
 

--- a/modules/building/pages/build-with-args.adoc
+++ b/modules/building/pages/build-with-args.adoc
@@ -1,4 +1,5 @@
 = Passing buildah arguments
+:description: Supplying build arguments to buildah via BUILD_ARGS_FILE in PipelineRuns.
 
 It is possible to link:https://github.com/containers/buildah/blob/main/docs/buildah-build.1.md[pass arguments to buildah] which is used to build container images in {ProductName}.
 

--- a/modules/building/pages/caching-proxy.adoc
+++ b/modules/building/pages/caching-proxy.adoc
@@ -1,4 +1,5 @@
 = Enabling caching proxy for builds
+:description: Enabling Squid-backed HTTP proxy caching for faster container layer pulls.
 
 {ProductName} supports HTTP proxy caching to improve build performance. When enabled, container build operations can use a Squid HTTP proxy to cache container image layers, reducing build times for subsequent builds.
 

--- a/modules/building/pages/component-nudges.adoc
+++ b/modules/building/pages/component-nudges.adoc
@@ -1,4 +1,5 @@
 = Defining component relationships
+:description: Cross-component relationships so digest updates open automatic PRs.
 
 When a tenant namespace includes multiple components, their repositories might contain references to image builds of another component. For example, an application might include multiple child components that, using a Dockerfile `FROM` clause, reference the image build of a common parent. Or, a component might reference image builds from another application altogether. OpenShift operators, for example, often have references to several components across applications.
 

--- a/modules/building/pages/configuration-as-code.adoc
+++ b/modules/building/pages/configuration-as-code.adoc
@@ -1,4 +1,5 @@
 = Configuring Applications and Components as Code with Kustomize
+:description: Modeling applications and components with Kustomize for repeatable configuration.
 
 If you need to define a large application with many components, easily duplicate or update components, or ensure consistent component and application states, consider configuring your {ProductName} applications and components as code using Kustomize. This document provides an overview of a basic application and component configuration that can be replicated and duplicated using Kustomize bases and overlays.
 

--- a/modules/building/pages/creating-forgejo.adoc
+++ b/modules/building/pages/creating-forgejo.adoc
@@ -1,4 +1,5 @@
 = Onboarding a component from Forgejo
+:description: Onboarding a component from a Forgejo repository using access tokens and secrets.
 
 Create components from Forgejo repositories using the {ProductName} UI or `kubectl`.
 

--- a/modules/building/pages/creating-github.adoc
+++ b/modules/building/pages/creating-github.adoc
@@ -1,4 +1,5 @@
 = Onboarding a component from GitHub
+:description: Onboarding a component from a GitHub repository using the GitHub App.
 
 Create components from GitHub repositories using the {ProductName} UI or `kubectl`.
 

--- a/modules/building/pages/creating-gitlab.adoc
+++ b/modules/building/pages/creating-gitlab.adoc
@@ -1,4 +1,5 @@
 = Onboarding a component from GitLab
+:description: Onboarding a component from a GitLab repository using access tokens and secrets.
 
 Create components from GitLab repositories using the {ProductName} UI or `kubectl`.
 

--- a/modules/building/pages/creating.adoc
+++ b/modules/building/pages/creating.adoc
@@ -1,4 +1,5 @@
 = Creating applications and components
+:description: How to create applications and components through the UI or kubectl.
 
 Create applications and components using the {ProductName} UI or `kubectl`.
 

--- a/modules/building/pages/custom-tags.adoc
+++ b/modules/building/pages/custom-tags.adoc
@@ -1,5 +1,6 @@
 [[custom-tags]]
 = Using custom tags
+:description: Configuring extra image tags through labels, parameters, or dynamic metadata.
 
 {ProductName} build pipelines allow you to apply multiple custom tags to your container images. This tagging is handled by separate `apply-tags` task. The custom tags can be configured in three ways:
 

--- a/modules/building/pages/customizing-the-build.adoc
+++ b/modules/building/pages/customizing-the-build.adoc
@@ -1,4 +1,5 @@
 = Customizing the build pipeline
+:description: Customizing PipelineRun parameters, timeouts, and tasks under .tekton.
 
 To meet your specific needs, you can customize the way that {ProductName} builds components. For instance:
 

--- a/modules/building/pages/deleting.adoc
+++ b/modules/building/pages/deleting.adoc
@@ -1,4 +1,5 @@
 = Deleting applications and components
+:description: Removing applications or components and the consequences for images and snapshots.
 
 You can delete a component or application if you are a user with the {ProductName} admin role.
 

--- a/modules/building/pages/hermetic-builds.adoc
+++ b/modules/building/pages/hermetic-builds.adoc
@@ -1,4 +1,5 @@
 = Enabling hermetic builds
+:description: Configuring network-isolated builds and tying them to dependency prefetching.
 
 A hermetic build is a secure, self-contained build process that doesn't depend on anything outside of the build environment. This means that it does not have network access, is not vulnerable to external influences, and cannot fetch dependencies at run time. Instead, you must declare all required resources and dependencies in your build definition. 
 

--- a/modules/building/pages/imagerepository.adoc
+++ b/modules/building/pages/imagerepository.adoc
@@ -1,4 +1,5 @@
 = Customizing ImageRepository
+:description: Adjusting ImageRepository visibility, credentials rotation, and Quay settings.
 
 == Changing repository visibility
 In the ImageRepository change `spec.image.visibility` to `private`(default) or `public` according what you want,

--- a/modules/building/pages/index.adoc
+++ b/modules/building/pages/index.adoc
@@ -1,4 +1,5 @@
 = Configuring your builds
+:description: How build pipelines work with attestations and where to customize build setup.
 
 When creating a component, {ProductName} will push a Tekton PipelineRun to your component's source repository. This pipeline is yours to customize as needed for building your component and Tekton Chains will record the customizations in a detailed signed in-toto provenance attestation. This provenance enables Conforma to xref:compliance:index.adoc[manage compliance] to ensure the artifact's integrity and compliance with specific policies.
 

--- a/modules/building/pages/labels-and-annotations.adoc
+++ b/modules/building/pages/labels-and-annotations.adoc
@@ -1,4 +1,5 @@
 = Labels and annotations
+:description: Adding dynamic OCI labels and annotations to images from pipeline parameters.
 
 {ProductName} allows applying dynamic metadata to images derived from properties and params of the build pipeline. The labelling is supported directly by the `LABELS` and `ANNOTATIONS` parameters of the *build-container* tasks. A supporting *generate-labels* task can optionally be used to produce some dynamic labels.
 

--- a/modules/building/pages/overriding-compute-resources.adoc
+++ b/modules/building/pages/overriding-compute-resources.adoc
@@ -1,4 +1,5 @@
 = Overriding compute resources
+:description: Overriding Tekton CPU and memory limits per task in PipelineRun specs.
 
 _For background on compute resources, see link:https://tekton.dev/docs/pipelines/compute-resources/[Compute Resources in Tekton]._
 

--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -1,4 +1,5 @@
 = Prefetching package manager dependencies for hermetic builds
+:description: Prefetching language dependencies with Hermeto for reproducible hermetic builds.
 
 In {ProductName}, you can run a hermetic build by restricting network access to the build; but without network access, a build will not be able to fetch component dependencies from remote repositories, and might fail. To avoid that, {ProductName} can prefetch dependencies for your hermetic builds using link:https://hermetoproject.github.io/hermeto[Hermeto].
 

--- a/modules/building/pages/prefetching-dependencies.adoc
+++ b/modules/building/pages/prefetching-dependencies.adoc
@@ -1,5 +1,5 @@
 = Prefetching package manager dependencies for hermetic builds
-:description: Prefetching language dependencies with Hermeto for reproducible hermetic builds.
+:description: Prefetching package manager dependencies with Hermeto for reproducible hermetic builds.
 
 In {ProductName}, you can run a hermetic build by restricting network access to the build; but without network access, a build will not be able to fetch component dependencies from remote repositories, and might fail. To avoid that, {ProductName} can prefetch dependencies for your hermetic builds using link:https://hermetoproject.github.io/hermeto[Hermeto].
 

--- a/modules/building/pages/pulp-access.adoc
+++ b/modules/building/pages/pulp-access.adoc
@@ -1,4 +1,5 @@
 = Getting Access to Pulp Storage
+:description: Requesting Pulp domains and secrets for non-OCI artifact storage.
 
 Pulp is the artifact storage system for non-container artifacts, including RPMs, Python wheels, Go modules, and generic files. Container images are stored in Quay, while all other build artifacts are stored in Pulp.
 

--- a/modules/building/pages/reconfiguring-build-pipeline.adoc
+++ b/modules/building/pages/reconfiguring-build-pipeline.adoc
@@ -1,4 +1,5 @@
 = Reconfiguring the build pipeline
+:description: Resetting or switching a component's build pipeline to a newer definition.
 
 After you have created a component {ProductName}, you may find yourself in a situation where you want to reset your build pipeline to the latest version. For instance:
 

--- a/modules/building/pages/redundant-rebuilds.adoc
+++ b/modules/building/pages/redundant-rebuilds.adoc
@@ -1,4 +1,5 @@
 = Preventing redundant builds
+:description: Tuning PaC on-cel-expression so PRs rebuild only affected components.
 
 {ProductName} rebuilds the component when new pull requests (PRs) include changes to that component. This behavior helps you identify any issues the PR might cause before merging it. 
 

--- a/modules/building/pages/running.adoc
+++ b/modules/building/pages/running.adoc
@@ -1,4 +1,5 @@
 = Running Build Pipelines
+:description: Triggering pre-merge and post-merge builds through Pipelines as Code.
 :page-aliases: rerunning.adoc
 
 Konflux uses xref:ROOT:getting-started.adoc#pipelines-as-code-pac[Pipelines as Code] (PaC) to run

--- a/modules/building/pages/scheduled-builds.adoc
+++ b/modules/building/pages/scheduled-builds.adoc
@@ -1,4 +1,5 @@
 = Scheduled builds with CronJobs
+:description: Scheduling default-branch push pipelines with Kubernetes CronJobs.
 
 The core principle is to create a `CronJob` that triggers a push pipeline using *the latest commit from the component's default branch*.
 

--- a/modules/building/pages/secrets/creating-registry-pull-secrets.adoc
+++ b/modules/building/pages/secrets/creating-registry-pull-secrets.adoc
@@ -1,4 +1,5 @@
 = Creating registry pull secrets
+:description: Registering pull secrets for private base images such as registry.redhat.io.
 
 Some container builds may use parent images from registries that require authentication, for example, `registry.redhat.io`. Until these credentials have been configured, the builds will continue to fail due to the system being unable to pull the required images.
 

--- a/modules/building/pages/secrets/creating-scm-secrets.adoc
+++ b/modules/building/pages/secrets/creating-scm-secrets.adoc
@@ -1,4 +1,5 @@
 = Creating source control management secrets
+:description: Storing SCM tokens for Pipeline-as-Code when not using the GitHub App.
 
 Some source control providers require authentication secrets to enable {ProductName} to access your repositories. This guide explains how to create and configure SCM (Source Control Management) secrets for Pipeline-as-Code integration.
 

--- a/modules/building/pages/secrets/creating-task-input-secrets.adoc
+++ b/modules/building/pages/secrets/creating-task-input-secrets.adoc
@@ -1,5 +1,5 @@
 = Creating task input secrets
-:description: Creating key/value secrets consumed by optional pipeline tasks.
+:description: Creating key/value secrets consumed by pipeline tasks that require them.
 
 Sometimes to run the tasks properly, you may need to pass secrets to these tasks. Consult the documentation for these tasks to understand the proper specification of the secrets required, for example the required keys/values.
 

--- a/modules/building/pages/secrets/creating-task-input-secrets.adoc
+++ b/modules/building/pages/secrets/creating-task-input-secrets.adoc
@@ -1,4 +1,5 @@
 = Creating task input secrets
+:description: Creating key/value secrets consumed by optional pipeline tasks.
 
 Sometimes to run the tasks properly, you may need to pass secrets to these tasks. Consult the documentation for these tasks to understand the proper specification of the secrets required, for example the required keys/values.
 

--- a/modules/building/pages/secrets/index.adoc
+++ b/modules/building/pages/secrets/index.adoc
@@ -1,4 +1,5 @@
 = Creating secrets for your builds
+:description: Overview of secret types for SCM, registry pulls, tasks, container mounts, and vaults.
 
 When you build your pipeline, you might want to add tasks that require **secrets** in order to access external resources.
 

--- a/modules/building/pages/secrets/referencing-secrets-in-containerfile.adoc
+++ b/modules/building/pages/secrets/referencing-secrets-in-containerfile.adoc
@@ -1,4 +1,5 @@
 = Referencing Secrets in a Containerfile
+:description: Mounting Kubernetes secrets into container builds with ADDITIONAL_SECRET.
 
 Sometimes you might need to reference a secret directly in your Containerfile. For example, if your build uses cryptographic parameters stored in secrets, you can use the `ADDITIONAL_SECRET` parameter to customize encryption in your Containerfile. For details, see the link:https://github.com/konflux-ci/build-definitions/tree/main/task/buildah-oci-ta/[buildah-oci-ta task documentation].
 

--- a/modules/building/pages/secrets/secrets-from-external-vaults.adoc
+++ b/modules/building/pages/secrets/secrets-from-external-vaults.adoc
@@ -1,3 +1,4 @@
 = Secrets from external vaults
+:description: Syncing secrets from external vaults using External Secrets Operator.
 
 include::partial${context}-secrets-external-vault.adoc[]

--- a/modules/building/pages/using-trusted-artifacts.adoc
+++ b/modules/building/pages/using-trusted-artifacts.adoc
@@ -1,4 +1,5 @@
 = Using Trusted Artifacts
+:description: Using Trusted Artifacts to securely share data between pipeline tasks.
 
 In order to retain the integrity of the build process, {ProductName} provides two modes of
 operation. The first is by ensuring that every Task in the build Pipeline is

--- a/modules/compliance/pages/customizing-policy.adoc
+++ b/modules/compliance/pages/customizing-policy.adoc
@@ -1,4 +1,5 @@
 = Customizing Policy
+:description: Waiving or adjusting Conforma policies when builds cannot satisfy default rules.
 
 A Conforma Policy defines which checks are performed by Conforma during integration tests and
 release. If Conforma reports violations, the best course of action, in most cases, is to adjust the build

--- a/modules/compliance/pages/index.adoc
+++ b/modules/compliance/pages/index.adoc
@@ -1,4 +1,5 @@
 = Managing compliance with Conforma
+:description: Conforma integration tests and attestation-based policy enforcement.
 
 Conforma is an artifact verifier and customizable policy checker. By default, {ProductName} adds Conforma as an integration test to each new application. Conforma then keeps your software supply chain secure and ensures container images comply with your organization's policies. It does this by verifying the security and provenance of builds created through {ProductName}.
 

--- a/modules/compliance/pages/policy-evaluations.adoc
+++ b/modules/compliance/pages/policy-evaluations.adoc
@@ -1,4 +1,5 @@
 = Policy Evaluations
+:description: Locating which policies are bound to integration tests and release admissions.
 
 In {ProductName}, there are two places where Conforma Policies are used by default,
 integration tests and release pipelines.

--- a/modules/end-to-end/pages/building-olm.adoc
+++ b/modules/end-to-end/pages/building-olm.adoc
@@ -1,4 +1,5 @@
 = Building an Operator Lifecycle Manager (OLM) Operator in {ProductName}
+:description: Building OLM operators, bundles, and file-based catalogs end to end.
 
 If you are developing an application that aligns with the link:https://operatorframework.io/[Operator Framework], and managing it with link:https://olm.operatorframework.io/docs/[Operator Lifecycle Manager (OLM)], you can build that application in {ProductName}. We refer to such applications as OLM Operators.
 

--- a/modules/end-to-end/pages/building-tekton-tasks.adoc
+++ b/modules/end-to-end/pages/building-tekton-tasks.adoc
@@ -1,4 +1,5 @@
 = Building Tekton tasks as bundles in {ProductName}
+:description: Onboarding Tekton task catalog repos to produce bundle images on Konflux.
 
 This document provides a step-by-step guide on how to onboard your Tekton tasks to {ProductName}, enabling their integration into your build pipelines.
 

--- a/modules/glossary/pages/index.adoc
+++ b/modules/glossary/pages/index.adoc
@@ -1,4 +1,5 @@
 = Glossary of terms related to {ProductName}
+:description: Definitions of Konflux terminology from pipelines through tenants and PAC.
 :icons: font
 :source-highlighter: highlightjs
 

--- a/modules/installing/pages/enabling-builds.adoc
+++ b/modules/installing/pages/enabling-builds.adoc
@@ -1,4 +1,5 @@
 = Enabling build pipelines
+:description: Enabling smee, GitHub App, image controller, and related build prerequisites.
 
 Before users can create an application in {ProductName}, you must enable build pipelines in your instance of {ProductName}. At the time of publication, this process includes configuring a smee channel, to listen for users' pull requests, and creating a xref:installing:github-app.adoc[GitHub App], so {ProductName} can access those PRs.
 

--- a/modules/installing/pages/github-app.adoc
+++ b/modules/installing/pages/github-app.adoc
@@ -1,4 +1,5 @@
 = GitHub App
+:description: Why and how the Konflux GitHub App powers Pipelines as Code integration.
 
 A *GitHub App* is a tool that extends GitHub's functionality. It can do things on GitHub like open issues, comment on pull requests, manage projects, etc.
 

--- a/modules/installing/pages/index.adoc
+++ b/modules/installing/pages/index.adoc
@@ -1,4 +1,5 @@
 = Installing {ProductName}
+:description: Installation paths for UI-based and manifest-based onboarding to Konflux.
 
 {ProductName} offers a comprehensive solution that fortifies your software supply chain against emerging threats. By providing detailed insights into the composition and construction of your software, {ProductName} enables proactive identification and mitigation of vulnerabilities.
 

--- a/modules/metadata/pages/attestations.adoc
+++ b/modules/metadata/pages/attestations.adoc
@@ -1,4 +1,5 @@
 = Inspecting artifact attestations
+:description: Downloading and inspecting Tekton Chains SLSA provenance attestations with cosign.
 
 Generally speaking, link:https://github.com/in-toto/attestation/blob/main/spec/README.md#in-toto-attestation-framework-spec[attestations] are authenticated metadata about software artifacts. An identity (and their private cryptographic key) are required to create an attestation for a software artifact. The primary attestation that {ProductName} generates is the SLSA provenance which is produced by link:https://tekton.dev/docs/concepts/supply-chain-security/[Tekton Chains]. This provenance contains information from the PipelineRun that generated the attested artifact including input parameters for the Tasks as well as Task results.
 

--- a/modules/metadata/pages/discover.adoc
+++ b/modules/metadata/pages/discover.adoc
@@ -1,4 +1,5 @@
 = Discovering the associated metadata
+:description: Using cosign and jq to list OCI referrers and metadata for built images.
 
 .Prerequisites
 

--- a/modules/metadata/pages/index.adoc
+++ b/modules/metadata/pages/index.adoc
@@ -1,4 +1,5 @@
 = Inspecting provenance and attestations
+:description: SLSA L3 supply-chain transparency and how to inspect build metadata.
 
 We are committed to providing exceptional security with {ProductName}. We harden the build platform, we provide transparency into the build process, and we expose the composition of artifacts.
 

--- a/modules/metadata/pages/sboms.adoc
+++ b/modules/metadata/pages/sboms.adoc
@@ -1,4 +1,5 @@
 = Inspecting artifact SBOMs
+:description: Build-time and release-time SBOMs: how they are generated and how to retrieve them.
 
 A software bill of materials (SBOM) provides greater transparency for your software supply chain. {ProductName} provides link:https://www.cisa.gov/sites/default/files/2023-04/sbom-types-document-508c.pdf[build SBOMs], which list all the software libraries that a component uses. Those libraries can enable specific functionality or facilitate development.
 

--- a/modules/metadata/pages/scan-results.adoc
+++ b/modules/metadata/pages/scan-results.adoc
@@ -1,4 +1,5 @@
 = Inspecting scan results
+:description: Fetching SARIF scan artifacts attached to images via the OCI referrers API.
 
 While you can inspect your scan results in the logs of your taskruns, it may be more convenient to work with those scan results as structured data. To support this, most {ProductName} scanning tasks produce results in the link:https://docs.oasis-open.org/sarif/sarif/[sarif format] and attach those results to the artifact using the link:https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md[OCI referrers api].
 

--- a/modules/mintmaker/pages/default-config.adoc
+++ b/modules/mintmaker/pages/default-config.adoc
@@ -1,4 +1,5 @@
 = Default configuration
+:description: Backend default Renovate presets and branch policies applied by MintMaker.
 
 MintMaker applies a set of default options for all repositories on backend.
 The configuration file can be found https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json[here].

--- a/modules/mintmaker/pages/rpm-lockfile.adoc
+++ b/modules/mintmaker/pages/rpm-lockfile.adoc
@@ -1,4 +1,5 @@
 = RPM lockfiles
+:description: Automating RPM lockfile refresh through MintMaker's RPM extension.
 
 == Introduction
 

--- a/modules/mintmaker/pages/security-updates.adoc
+++ b/modules/mintmaker/pages/security-updates.adoc
@@ -1,4 +1,5 @@
 = Security updates
+:description: CVE-titled security update PRs generated automatically by MintMaker.
 
 Beginning March 2025 MintMaker provides security updates for container images
 and xref:mintmaker:rpm-lockfile.adoc[RPM lockfiles]. In their nature, the security updates are like regular dependency updates, but with included information

--- a/modules/mintmaker/pages/support.adoc
+++ b/modules/mintmaker/pages/support.adoc
@@ -1,4 +1,5 @@
 = Dependency Management Support Matrix
+:description: Matrix of supported dependency managers, versions, and known limitations.
 
 This page details the compatibility, support and implementation limitations
 of certain managers. It is intended to supply xref:mintmaker:user.adoc#available-managers[the list of currently supported managers].

--- a/modules/mintmaker/pages/user.adoc
+++ b/modules/mintmaker/pages/user.adoc
@@ -1,4 +1,5 @@
 = Dependency Management
+:description: User guide to MintMaker/Renovate configuration, scheduling, and dependency managers.
 == Introduction
 
 MintMaker is a service built on top of https://docs.renovatebot.com/[Renovate]. It includes the xref:mintmaker:rpm-lockfile.adoc[RPM lockfile extension] and integration with https://konflux-ci.dev/[Konflux CI].

--- a/modules/patterns/pages/centralize-pipeline-definitions.adoc
+++ b/modules/patterns/pages/centralize-pipeline-definitions.adoc
@@ -1,4 +1,5 @@
 = Pattern: Centralizing Tekton Pipeline Definitions in Your Repository
+:description: Extracting one Pipeline manifest referenced by multiple PipelineRuns in a repo.
 
 This pattern describes how to extract a common Tekton `Pipeline` definition into a local file within your application's Git repository (e.g., `.tekton/build-pipeline.yaml`). Your `PipelineRun` files can then reference this local pipeline, promoting consistency, simplifying maintenance, and enabling version control of the pipeline logic alongside your application code.
 

--- a/modules/patterns/pages/git-submodules.adoc
+++ b/modules/patterns/pages/git-submodules.adoc
@@ -1,4 +1,5 @@
 = Building upstream projects with git submodules
+:description: Syncing upstream code into downstream repos using Git submodules and automation.
 
 This document outlines a basic guide for synchronizing changes between an upstream and downstream repository using Git submodules.
 

--- a/modules/patterns/pages/github-merge-queues.adoc
+++ b/modules/patterns/pages/github-merge-queues.adoc
@@ -1,4 +1,5 @@
 = GitHub Merge Queues
+:description: Configuring Konflux PR pipelines to work with GitHub merge queues.
 
 This document contains instructions for how to configure GitHub link:https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue[merge queues] with {ProductName}.
 

--- a/modules/patterns/pages/gitops-for-manual-releases.adoc
+++ b/modules/patterns/pages/gitops-for-manual-releases.adoc
@@ -1,4 +1,5 @@
 = GitOps for Manual Releases
+:description: Exporting snapshots to Git for reviewed, manual release promotion.
 
 While {ProductName} supports continuous delivery as a first-class feature controlled by the `release.appstudio.openshift.io/auto-release` label on the xref:releasing:create-release-plan.adoc[ReleasePlan] and supported by the use of xref:releasing:using-collectors.adoc[release metadata collectors], for various reasons, some teams prefer to manage their release process in a slower paced, higher-touch manner.
 

--- a/modules/patterns/pages/index.adoc
+++ b/modules/patterns/pages/index.adoc
@@ -1,4 +1,5 @@
 = How-to guides for {ProductName} integrated repositories
+:description: Index of advanced how-to guides for Konflux-integrated repositories.
 
 Depending on your use case, there are several guidelines you can use for repositories that are integrated with {ProductName}:
 

--- a/modules/patterns/pages/keep-remote-pipelines-up-to-date.adoc
+++ b/modules/patterns/pages/keep-remote-pipelines-up-to-date.adoc
@@ -1,4 +1,5 @@
 = Maintaining remote Tekton pipelines
+:description: Hosting shared pipelines in Git and resolving them from component repos.
 
 [IMPORTANT]
 ====

--- a/modules/patterns/pages/maintaining-references-before-release.adoc
+++ b/modules/patterns/pages/maintaining-references-before-release.adoc
@@ -1,4 +1,5 @@
 = Maintaining valid image references before a release
+:description: Mapping release targets so nudges rewrite digests for post-release registries.
 
 When images are xref:releasing:index.adoc[released] they will usually be copied to another image repository. If any build-time image references are used within component (for example, xref:end-to-end:building-olm.adoc[OLM bundles]) any references will be invalid after releasing. To surmount this, {ProductName} enables your xref:building:component-nudges.adoc[component nudges] to be updated with image references which will be valid after release.
 

--- a/modules/patterns/pages/managing-monorepo-applications.adoc
+++ b/modules/patterns/pages/managing-monorepo-applications.adoc
@@ -1,4 +1,5 @@
 = Managing Monorepo Applications
+:description: Tuning monorepo triggers, submodules, tests, and releases on Konflux.
 
 In most cases, {ProductName} applications consist of multiple components each with its own repository.
 However, there are legitimate use-cases where users need to keep multiple components within the same repository.

--- a/modules/patterns/pages/managing-multiple-versions.adoc
+++ b/modules/patterns/pages/managing-multiple-versions.adoc
@@ -1,4 +1,5 @@
 = Managing multiple software versions
+:description: Using Project CRDs to template parallel software version streams.
 
 NOTE: The Project Controller here is considered *experimental*. API and support may change in the future.
 

--- a/modules/patterns/pages/managing-pipeline-changes.adoc
+++ b/modules/patterns/pages/managing-pipeline-changes.adoc
@@ -1,4 +1,5 @@
 = Pattern: Evolving Build Pipeline Management in {ProductName}
+:description: Evolving from embedded pipeline specs to shared local and remote Tekton pipelines.
 
 This pattern outlines a common evolution in managing Tekton build pipelines within {ProductName}. It begins with the initial setup provided by {ProductName}, progresses to local in-repository pipeline definition for customization and reuse within a single repository, and can further evolve to sharing customized pipelines across multiple repositories using Git-based references.
 

--- a/modules/patterns/pages/managing-security-fix.adoc
+++ b/modules/patterns/pages/managing-security-fix.adoc
@@ -1,4 +1,5 @@
 = Managing a security fix
+:description: Using private mirrors and tenants to develop and ship embargoed security fixes.
 
 Sometimes, you need to address an **embargoed security issue** in your application. So as not to disclose aspects of the security vulnerability prematurely, you will want to prepare a fix in private or with a limited set of collaborators. This document guides you on how to make a private copy of your Git repository and clone your application to a private tenant namespace where you can prepare a fix and invite other collaborators only on a need-to-know basis, so that you can control who is aware of the issue while you develop the fix.
 

--- a/modules/patterns/pages/mapping-tags-to-labels.adoc
+++ b/modules/patterns/pages/mapping-tags-to-labels.adoc
@@ -1,4 +1,5 @@
 = Pattern: Achieving Label and Tag Parity for Versioning
+:description: Keeping OCI version labels and image tags in sync from shared Git parameters.
 
 This pattern describes how to configure your {ProductName} build pipeline to ensure parity between a version label (e.g., `org.opencontainers.image.version`) on your container image and a human-readable image tag. This enhances image traceability and makes it easier for users and tools to identify image versions consistently.
 

--- a/modules/patterns/pages/running-user-scripts-on-the-build-pipeline.adoc
+++ b/modules/patterns/pages/running-user-scripts-on-the-build-pipeline.adoc
@@ -1,4 +1,5 @@
 = Running user scripts on the build pipeline
+:description: Running custom scripts before the image build step in trusted-artifact pipelines.
 
 This document contains instructions for how to extend the build pipeline of a component to run a script before building the component container.
 

--- a/modules/patterns/pages/slack-notifications.adoc
+++ b/modules/patterns/pages/slack-notifications.adoc
@@ -1,4 +1,5 @@
 = Slack Notifications
+:description: Sending Slack webhook alerts from pipeline finally blocks.
 
 We live in slack. You may find it helpful to route notifications there from your pipelines.
 

--- a/modules/patterns/pages/testing-releasing-single-component.adoc
+++ b/modules/patterns/pages/testing-releasing-single-component.adoc
@@ -1,4 +1,5 @@
 = Testing and Releasing a Single Component
+:description: Isolating Conforma and release gating per component within an application.
 
 By default, {ProductName} treats applications as a set of dependent components. A example would be frontend and backend
 components. A user may typically want to build, test, and release these components together

--- a/modules/reference/nav.adoc
+++ b/modules/reference/nav.adoc
@@ -1,5 +1,6 @@
 * xref:index.adoc[Reference]
 ** xref:sample-repositories.adoc[Sample repositories]
+** xref:llms-txt.adoc[LLM-friendly documentation (llms.txt)]
 ** xref:kube-apis/index.adoc[Konflux Kubernetes APIs]
 *** xref:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-application[Application]
 *** xref:kube-apis/application-api.adoc#k8s-api-github-com-konflux-ci-application-api-api-v1alpha1-component[Component]

--- a/modules/reference/pages/index.adoc
+++ b/modules/reference/pages/index.adoc
@@ -1,4 +1,5 @@
 = Reference
+:description: Pointers to sample repositories, Kubernetes APIs, and other reference material.
 
 == Sample repositories
 

--- a/modules/reference/pages/kube-apis/index.adoc
+++ b/modules/reference/pages/kube-apis/index.adoc
@@ -1,4 +1,5 @@
 = Konflux Kubernetes APIs
+:description: Index of Konflux custom resource API specifications.
 
 Below are the Kubernetes API extensions added by Konflux.
 

--- a/modules/reference/pages/llms-txt.adoc
+++ b/modules/reference/pages/llms-txt.adoc
@@ -1,0 +1,129 @@
+= LLM-friendly documentation (llms.txt)
+:description: The published llms.txt index and MCP tooling for AI coding assistants.
+
+{ProductName} publishes an https://llmstxt.org/[llms.txt] file — a structured
+index that lets Large Language Models discover and consume the documentation at
+inference time. The file is automatically regenerated on every documentation build,
+so it always reflects the current state of the docs.
+
+*Published at:* https://konflux-ci.dev/docs/llms.txt
+
+== What is llms.txt?
+
+`llms.txt` is a lightweight specification for providing LLM-readable content on
+websites. It is a Markdown file containing a title, a short description, and a
+categorised list of links to documentation pages. AI coding assistants and
+MCP-enabled IDEs can read this file to find relevant documentation without
+scraping HTML.
+
+== Using with an MCP server (mcpdoc)
+
+https://github.com/langchain-ai/mcpdoc[mcpdoc] is an open-source MCP server
+purpose-built for serving `llms.txt` files. It exposes two tools to MCP host
+applications (Cursor, Windsurf, Claude Code/Desktop):
+
+* *`list_doc_sources`* — lists available documentation sources.
+* *`fetch_docs`* — fetches content from URLs found in the `llms.txt` file.
+
+=== {ProductName} llms.txt URLs
+
+Use the following names and URLs when configuring mcpdoc. You can add one or both
+depending on the documentation you need:
+
+[cols="1,2",options="header"]
+|===
+| Name | URL
+
+| `Konflux Documentation`
+| `https://konflux-ci.dev/docs/llms.txt`
+
+| `Konflux Operator And Administrator Documentation`
+| `https://konflux-ci.dev/konflux-ci/llms.txt`
+|===
+
+=== Quick start (Cursor example)
+
+Open *Cursor Settings > MCP* to edit your `~/.cursor/mcp.json`, then add:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "konflux-docs": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "mcpdoc",
+        "mcpdoc",
+        "--urls",
+        "Konflux Documentation:https://konflux-ci.dev/docs/llms.txt",
+        "Konflux Operator And Administrator Documentation:https://konflux-ci.dev/konflux-ci/llms.txt",
+        "--transport",
+        "stdio"
+      ]
+    }
+  }
+}
+----
+
+For best results, add a rule to your Cursor *User Rules* (Settings > Rules):
+
+[source,text]
+----
+For ANY question about Konflux — builds, testing, releases, compliance, or
+installation — use the konflux-docs MCP server:
+1. Call list_doc_sources to see available llms.txt files
+2. Call fetch_docs to read the llms.txt index
+3. Identify URLs relevant to the question
+4. Call fetch_docs on those URLs
+5. Use the retrieved content to answer
+----
+
+=== Other IDEs and clients
+
+mcpdoc supports Cursor, Windsurf, Claude Code, and Claude Desktop. For setup
+instructions for each client, see the
+https://github.com/langchain-ai/mcpdoc?tab=readme-ov-file#quickstart[mcpdoc Quickstart guide].
+The configuration is the same across clients — only the `--urls` value is
+{ProductName}-specific:
+
+[source,text]
+----
+Konflux Documentation:https://konflux-ci.dev/docs/llms.txt
+Konflux Operator And Administrator Documentation:https://konflux-ci.dev/konflux-ci/llms.txt
+----
+
+=== Testing with the MCP Inspector
+
+Start mcpdoc in SSE mode:
+
+[source,bash]
+----
+uvx --from mcpdoc mcpdoc \
+    --urls "Konflux Documentation:https://konflux-ci.dev/docs/llms.txt" \
+    --transport sse \
+    --port 8082 \
+    --host localhost
+----
+
+Then launch the https://modelcontextprotocol.io/docs/tools/inspector[MCP Inspector]:
+
+[source,bash]
+----
+npx @modelcontextprotocol/inspector
+----
+
+In the Inspector UI, set the transport to *SSE*, enter `http://localhost:8082/sse`,
+and click *Connect*. Use the *Tools* tab to call `list_doc_sources` and
+`fetch_docs`.
+
+== How llms.txt is generated
+
+The file is produced by `hack/generate-llms-txt.sh`, which scans the Antora
+content tree and extracts each page's title and introductory paragraph from the
+AsciiDoc source files. It uses the `nav.adoc` files to determine page ordering and
+section structure.
+
+The script runs automatically as part of the CI build pipeline, so any change to
+the documentation — new pages, updated titles, restructured navigation — is
+reflected in `llms.txt` on the next deploy.

--- a/modules/reference/pages/sample-repositories.adoc
+++ b/modules/reference/pages/sample-repositories.adoc
@@ -1,4 +1,5 @@
 = Sample repositories
+:description: Official example repositories illustrating various Konflux setups.
 
 There are multiple sample repositories which demonstrate various functionality within {ProductName}. You can
 either use these as reference or you can fork them and try to onboard the repositories yourself.

--- a/modules/releasing/pages/adjusting-timeouts-resources.adoc
+++ b/modules/releasing/pages/adjusting-timeouts-resources.adoc
@@ -1,4 +1,5 @@
 = Adjusting timeouts and resources
+:description: Extending release PipelineRun timeouts and TaskRun compute resources.
 
 When a Release Pipeline is executed through a PipelineRun, the Pipeline will run until a timeout is reached. This timeout is usually an hour and will make the Release Pipeline fail if it doesn't finish on time.
 

--- a/modules/releasing/pages/create-release-plan-admission.adoc
+++ b/modules/releasing/pages/create-release-plan-admission.adoc
@@ -1,4 +1,5 @@
 = Creating a release plan admission
+:description: Defining ReleasePlanAdmission CRs with pipelines and policy in managed namespaces.
 
 A ReleasePlanAdmission (RPA) CR exists within a managed tenant namespace. It defines the specific pipeline to run and a given xref:compliance:index.adoc[Conforma] Policy which needs to pass for the Snapshot before that pipeline can proceed.
 

--- a/modules/releasing/pages/create-release-plan.adoc
+++ b/modules/releasing/pages/create-release-plan.adoc
@@ -1,4 +1,5 @@
 = Creating a release plan
+:description: Defining ReleasePlan CRs for snapshot promotion and optional automation.
 
 A ReleasePlan (RP) CR is created for a specific Application. It defines the process to release a specific Application Snapshot in a target tenant namespace, whether automatic releases are enabled, as well as additional data to pass to a corresponding RPA.
 

--- a/modules/releasing/pages/create-release.adoc
+++ b/modules/releasing/pages/create-release.adoc
@@ -1,4 +1,5 @@
 = Creating a release
+:description: Creating a Release CR to promote a snapshot through an approved ReleasePlan.
 
 A `Release` object informs Konflux that an Application's
 xref:testing:page$integration/snapshots/index.adoc[Snapshot] is ready to be released, in accordiance

--- a/modules/releasing/pages/index.adoc
+++ b/modules/releasing/pages/index.adoc
@@ -1,4 +1,5 @@
 = Releasing an application
+:description: Development versus managed-environment roles in Konflux release workflows.
 :icons: font
 :numbered:
 :source-highlighter: highlightjs

--- a/modules/releasing/pages/retrigger-release.adoc
+++ b/modules/releasing/pages/retrigger-release.adoc
@@ -1,4 +1,5 @@
 = Re-trigger a release manually
+:description: Re-triggering a release by creating a new Release CR with the same spec.
 
 `Release` objects create workloads with a finite lifecycle. Once created, a `Release` object's `spec` field cannot be modified.
 To "re-trigger" a release, create a new instance of the desired `Release` object using the same values in the `spec` field.

--- a/modules/releasing/pages/tenant-release-pipelines.adoc
+++ b/modules/releasing/pages/tenant-release-pipelines.adoc
@@ -1,4 +1,5 @@
 = Tenant Release Pipelines
+:description: Running pre-release steps in the developer tenant namespace via tenantPipeline.
 
 The usual release process in {ProductName} involves two different teams: a *Development team* and a *Managed environment team* as described in
 xref:releasing:index.adoc[Releasing an application]. The development team is usually the one who develops and support the application while the managed team will control the process and the secrets. Although this is a powerful workflow, in some cases it might feel very limiting. For example, sometimes the Development team wants to release their software to some destination that is directly under their control, using their own secrets, without depending on a Managed environment team. Another example would be performing actions before running the managed pipeline such as cleaning up old images or notifying about an ongoing release. The way {ProductName} supports these scenarios is by using something we call a *tenant release pipeline*. It's a release pipeline that runs in the tenant namespace of the Development team, rather than in that of the Managed environment team.

--- a/modules/releasing/pages/using-collectors.adoc
+++ b/modules/releasing/pages/using-collectors.adoc
@@ -1,4 +1,5 @@
 = Collectors
+:description: Using collector scripts to fetch dynamic data into release status early.
 
 The release process with {ProductName} is well-structured, and the documentation provides clear examples of how to supply data to the `Release`, `ReleasePlan`, or `ReleasePlanAdmission` resources for use within the release workflow.
 

--- a/modules/testing/pages/build/index.adoc
+++ b/modules/testing/pages/build/index.adoc
@@ -1,4 +1,5 @@
 = Build-time tests
+:description: Default build-time security and quality Tekton tasks that run automatically.
 
 This document covers the build-time tests that {ProductName} runs as part of its component build pipeline. These build-time tests automatically check all application images to inform you if they're up-to-date, correctly formatted, and protected from security vulnerabilities.
 

--- a/modules/testing/pages/build/snyk.adoc
+++ b/modules/testing/pages/build/snyk.adoc
@@ -1,4 +1,5 @@
 = Enabling a Snyk task
+:description: Enabling Snyk SAST by wiring a token secret into the build pipeline.
 
 The Snyk test is available to run at build time in the default pipelines, but it requires additional configuration to enable. This procedural example illustrates a build-time test that requires the configuration of a custom secret.
 

--- a/modules/testing/pages/index.adoc
+++ b/modules/testing/pages/index.adoc
@@ -1,4 +1,5 @@
 = Testing your components and applications
+:description: Overview of build-time, custom, and integration testing on Konflux.
 
 You can ensure that your applications are stable, secure, compliant, and mutually compatible by implementing tests for {ProductName} to run on their components. There are currently 3 types of tests in {ProductName}:
 

--- a/modules/testing/pages/integration/accessing-private-repositories.adoc
+++ b/modules/testing/pages/integration/accessing-private-repositories.adoc
@@ -1,4 +1,5 @@
 = Accessing Private Repositories
+:description: Linking registry and Git secrets for private integration pipelines.
 
 == Accessing Images in Private Repositories
 

--- a/modules/testing/pages/integration/adding.adoc
+++ b/modules/testing/pages/integration/adding.adoc
@@ -1,4 +1,5 @@
 = Adding an integration test
+:description: Registering an integration test scenario pointing at a Git pipeline definition.
 
 In {ProductName}, you can add integration tests to verify that the individual components of your application integrate correctly, forming a complete and functional application. {ProductName} runs these integration tests on the container images of components before their release.
 

--- a/modules/testing/pages/integration/canceling.adoc
+++ b/modules/testing/pages/integration/canceling.adoc
@@ -1,4 +1,5 @@
 = Canceling Integration pipelineRuns
+:description: Manual cancellation and automatic supersession when snapshots refresh.
 
 == How do I cancel the previous pipelineRun and which will be canceled?
 

--- a/modules/testing/pages/integration/choosing-contexts.adoc
+++ b/modules/testing/pages/integration/choosing-contexts.adoc
@@ -1,4 +1,5 @@
 = Choosing when to run certain Integration Tests
+:description: Selecting IntegrationTestScenario contexts for PRs, pushes, overrides, and groups.
 
 Integration test scenarios can be configured to run in only certain cases (referred to as contexts in further text).
 Examples include running the integration test pipelines only in case of Pull Requests, or running them only for builds of specific components.

--- a/modules/testing/pages/integration/creating.adoc
+++ b/modules/testing/pages/integration/creating.adoc
@@ -1,4 +1,5 @@
 = Creating a custom integration test
+:description: Authoring a custom Tekton integration pipeline and publishing it from Git.
 
 In {ProductName}, you can create your own integration tests to run on all components of a given application before they are deployed.
 

--- a/modules/testing/pages/integration/debugging.adoc
+++ b/modules/testing/pages/integration/debugging.adoc
@@ -1,4 +1,5 @@
 = Debugging Integration Tests
+:description: Finding failed integration PipelineRuns via activity views and logs.
 
 In case of an integration test scenario failing, there are several steps to take in order to debug the issue before rerunning the test in question. These steps are outlined below.
 

--- a/modules/testing/pages/integration/disable-integration-comment.adoc
+++ b/modules/testing/pages/integration/disable-integration-comment.adoc
@@ -1,4 +1,5 @@
 = Disabling Integration Test Comments on GitLab Merge Requests
+:description: Suppressing GitLab MR comments via component annotations.
 
 In {ProductName}, when a Merge Request (MR) is committed and integration test are triggered, if the GitLab source control secret has api, read_repository and write_repository scopes, the Integration service creates a commitStatus for the commit on the MR. The integration test status includes information about whether the tests are pending, triggered, passed or failed for each component involved in the MR.
 

--- a/modules/testing/pages/integration/editing.adoc
+++ b/modules/testing/pages/integration/editing.adoc
@@ -1,4 +1,5 @@
 = Editing integration tests
+:description: Updating integration test Git refs, paths, parameters, and release settings.
 
 Once you have xref:./adding.adoc[added] an Integration Test Scenario to {ProductName}, you may want to change the configurations for it. 
 

--- a/modules/testing/pages/integration/index.adoc
+++ b/modules/testing/pages/integration/index.adoc
@@ -1,4 +1,5 @@
 = Integration tests
+:description: How integration tests, snapshots, and the Global Candidate List work together.
 
 This document covers the integration tests that {ProductName} triggers after component build pipelines. 
 

--- a/modules/testing/pages/integration/logs-to-quay.adoc
+++ b/modules/testing/pages/integration/logs-to-quay.adoc
@@ -1,4 +1,5 @@
 = Export Pipeline Logs to Quay
+:description: Archiving full PipelineRun logs to the image registry with export-pipeline-logs.
 
 Use the `export-pipeline-logs` task to gather all execution logs from a completed Tekton PipelineRun and package them into a compressed `tar.gz` artifact.
 

--- a/modules/testing/pages/integration/periodic-integration-tests.adoc
+++ b/modules/testing/pages/integration/periodic-integration-tests.adoc
@@ -1,4 +1,5 @@
 = Triggering Periodic Integration Tests
+:description: Running integration tests on a schedule via CronJobs and snapshot labeling.
 
 In {ProductName}, you can run integration tests on a schedule using Kubernetes CronJobs.
 

--- a/modules/testing/pages/integration/rerunning.adoc
+++ b/modules/testing/pages/integration/rerunning.adoc
@@ -1,4 +1,5 @@
 = Retriggering Integration Tests
+:description: Re-triggering integration tests by labeling snapshots with run selectors.
 
 Integration test(s) for a given snapshot can be re-triggered by adding the `test.appstudio.openshift.io/run` label to the snapshot.
 

--- a/modules/testing/pages/integration/snapshots/group-snapshots.adoc
+++ b/modules/testing/pages/integration/snapshots/group-snapshots.adoc
@@ -1,4 +1,5 @@
 = Creating a group snapshot
+:description: Coordinating linked PR branches into group snapshots across components.
 
 In {ProductName}, the integration service provides extra `group` snapshot to allow users to submit multiple related pull/merge requests under one application to their repos, have them tested together and have the CI results posted back to pull/merge requests, along with the component snapshot created for each component.
 

--- a/modules/testing/pages/integration/snapshots/index.adoc
+++ b/modules/testing/pages/integration/snapshots/index.adoc
@@ -1,4 +1,5 @@
 = Snapshots
+:description: Snapshots as immutable component image sets for testing and releasing.
 
 // Optional: Define context for cross-references if needed within the module structure
 // :context: snapshots

--- a/modules/testing/pages/integration/snapshots/override-snapshots.adoc
+++ b/modules/testing/pages/integration/snapshots/override-snapshots.adoc
@@ -1,4 +1,5 @@
 = Creating an override snapshot
+:description: Resetting Global Candidate Lists with labeled override snapshots.
 
 In {ProductName}, the integration service provides users with the ability to reset their component's Global Candidate List to a desired state with a manually created `override` snapshot which can then be a candidate for further promotion (release) if it passes all integration tests.
 

--- a/modules/testing/pages/integration/snapshots/working-with-snapshots.adoc
+++ b/modules/testing/pages/integration/snapshots/working-with-snapshots.adoc
@@ -1,4 +1,5 @@
 = Working with Snapshots
+:description: Creating and verifying kubectl-defined manual snapshots.
 
 == Manual Snapshots
 

--- a/modules/testing/pages/integration/standardized-outputs.adoc
+++ b/modules/testing/pages/integration/standardized-outputs.adoc
@@ -1,4 +1,5 @@
 = Standardized outputs
+:description: TEST_OUTPUT, SCAN_OUTPUT, and other structured Tekton result formats.
 
 Konflux is using standardized outputs in various places, this part of docs will provide more detail information about it.
 Each one of the results described below is rendered in the UI, you simply click on task name and panel with details is showed

--- a/modules/testing/pages/integration/third-parties/jenkins.adoc
+++ b/modules/testing/pages/integration/third-parties/jenkins.adoc
@@ -1,4 +1,5 @@
 = Jenkins
+:description: Triggering external Jenkins jobs from a Konflux integration test.
 
 In this guide, you'll learn how to xref:testing:integration/adding.adoc[add a custom integration test] in {ProductName} that triggers a link:https://www.jenkins.io/[jenkins] job in a jenkins instance outside of konflux using the jenkins link:https://www.jenkins.io/doc/book/using/remote-access-api/[remote access API].
 

--- a/modules/testing/pages/integration/third-parties/openshift-ci.adoc
+++ b/modules/testing/pages/integration/third-parties/openshift-ci.adoc
@@ -1,4 +1,5 @@
 = OpenShift CI
+:description: Integrating with OpenShift CI through ProwJobs or ephemeral-cluster tasks.
 
 The OpenShift CI platform provides two ways through which a {ProductName} pipeline can interact with it.
 

--- a/modules/testing/pages/integration/third-parties/rapidast.adoc
+++ b/modules/testing/pages/integration/third-parties/rapidast.adoc
@@ -1,4 +1,5 @@
 = RapiDAST
+:description: Running dynamic application security testing (DAST) with RapiDAST.
 
 link:https://github.com/RedHatProductSecurity/rapidast[RapiDAST] is a tool for performing dynamic application security testing (DAST) on _running_ applications.
 

--- a/modules/testing/pages/integration/third-parties/testing-farm.adoc
+++ b/modules/testing/pages/integration/third-parties/testing-farm.adoc
@@ -1,3 +1,4 @@
 = Testing Farm
+:description: Running integration tests using Testing Farm's Tekton integration.
 
 In order to learn how to xref:testing:integration/adding.adoc[add a custom integration test] in {ProductName} that uses link:https://docs.testing-farm.io/[Testing Farm], please see link:https://gitlab.com/testing-farm/integrations-konflux#user-content-usage-in-konflux-ci[gitlab.com/testing-farm/integrations/tekton].

--- a/modules/troubleshooting/pages/builds.adoc
+++ b/modules/troubleshooting/pages/builds.adoc
@@ -1,4 +1,5 @@
 = Troubleshooting Builds
+:description: Diagnosing and fixing common build failures such as disk, network, and workspace issues.
 
 == No space left on device
 

--- a/modules/troubleshooting/pages/registries.adoc
+++ b/modules/troubleshooting/pages/registries.adoc
@@ -1,4 +1,5 @@
 = Troubleshooting Registry Issues
+:description: Debugging Tekton registry auth wiring and push or pull errors.
 
 == Failed to push or pull image
 

--- a/modules/troubleshooting/pages/releases.adoc
+++ b/modules/troubleshooting/pages/releases.adoc
@@ -1,4 +1,5 @@
 = Troubleshooting Releases
+:description: Diagnosing release signature failures and related pipeline problems.
 
 == Release fails because of signature check
 

--- a/modules/troubleshooting/pages/service-accounts.adoc
+++ b/modules/troubleshooting/pages/service-accounts.adoc
@@ -1,4 +1,5 @@
 = Troubleshooting Service Account Authentication
+:description: Resolving invalid or expired externally issued service-account tokens.
 
 == Token invalid or expired
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "api-gen": "./hack/gen-api-docs.sh",
     "build": "antora generate --clean --fetch antora-playbook.yml",
+    "generate-llms-txt": "bash hack/generate-llms-txt.sh public/llms.txt",
     "preview:netlify": "netlify deploy --dir public",
     "lint:docs": "./hack/vale-check.sh",
     "lint:docs:errors": "./hack/vale-check.sh --minAlertLevel=error",


### PR DESCRIPTION
## Summary

- Add `hack/generate-llms-txt.sh` that scans Antora navigation files and extracts the `:description:` document attribute from each AsciiDoc page to build an [llms.txt](https://llmstxt.org/) index -- a structured Markdown file that LLMs and MCP-enabled IDEs can consume at inference time.
- Add a `:description:` attribute to all ~110 `.adoc` page headers, giving every page a concise one-line summary used both for HTML meta descriptions and for `llms.txt`.
- Wire `llms.txt` generation into CI (`checks.yaml`, `publish.yaml`) and `package.json` so it rebuilds automatically on every deploy.
- Add a new reference page (`modules/reference/pages/llms-txt.adoc`) explaining the `llms.txt` feature and how to use it with [mcpdoc](https://github.com/langchain-ai/mcpdoc) in Cursor, Claude Code, and other MCP clients.
- Update `.gemini/styleguide.md` to require the `:description:` attribute on every new page.

## Test plan

- [ ] CI checks pass (`npm run build && npm run generate-llms-txt`)
- [ ] Review generated `public/llms.txt` for completeness and description quality
- [ ] Verify the new reference page renders correctly in the Antora site
- [ ] Spot-check a few `.adoc` pages to confirm `:description:` is placed correctly in the document header


Made with [Cursor](https://cursor.com)