### PR TITLE
fix(remote pipelines): improve the remote pipelines recommendation

### DIFF
--- a/modules/patterns/pages/keep-remote-pipelines-up-to-date.adoc
+++ b/modules/patterns/pages/keep-remote-pipelines-up-to-date.adoc
@@ -21,7 +21,7 @@ If the repository is private, be sure to have a Secret in your {ProductName} ten
 
 .*Procedures*
 
-. Add Tekton Pipelines and Tasks in the repository. A suggested repository structure would be:
+. Add Tekton Pipelines and Tasks in the repository. Here is a suggested repository structure:
 
 +
 [source,shell]
@@ -29,13 +29,13 @@ If the repository is private, be sure to have a Secret in your {ProductName} ten
 .
 ├── .tekton
 │   ├── <repository-name>-pipelines-pull-request.yaml <.>
-│   └── <repository-name>-pipelines-push.yaml <.>
-├── pipelines
-│   ├── remote-pipeline1.yaml
-│   └── remote-pipeline2.yaml
-├── tasks
-│   ├── remote-task1.yaml
-│   └── remote-task2.yaml
+│   ├── <repository-name>-pipelines-push.yaml <.>
+│   ├── pipelines
+│   │   ├── remote-pipeline1.yaml
+│   │   └── remote-pipeline2.yaml
+│   └── tasks
+│       ├── remote-task1.yaml
+│       └── remote-task2.yaml
 └── renovate.json <.>
 ----
 
@@ -44,9 +44,27 @@ If the repository is private, be sure to have a Secret in your {ProductName} ten
 <.> Used by {ProductName} to monitor pushes.
 <.> Renovate/MintMaker configuration.
 
+Use link:https://pipelinesascode.com/docs/guides/pipeline-resolution/[Pipelines as Code's resolver] with this structure to reference pipelines and tasks with a simple *pipelineRef*:
+
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata: ... <.>
+spec:
+  pipelineRef:
+    name: pipeline-1 <.>
+----
+
+<.> Omitted for brevity. No additional annotations are required to reference the pipeline or task if they exist in the `+.tekton+` directory.
+<.> Specify the name of the pipeline. Note: this is the pipeline's `+metadata.name+`, not the filename.
+
+This has the added benefits of faster resolution and fewer API requests than other pipeline resolution methods because Pipelines as Code already parses the Pipelines and Tasks from the `+.tekton+` directory when looking for PipelineRuns to match.
+
 === Use git resolver
 
-To start referencing a remote Pipeline from a PipelineRun using a *git resolver*, replace *pipelineSpec* with *pipelineRef*:
+Use the *git resolver* to reference a pipeline that exists in another repository.
+To start referencing a remote Pipeline from a PipelineRun by using the *git resolver*, replace *pipelineSpec* with *pipelineRef*:
 
 [source,yaml]
 ----

--- a/modules/patterns/pages/keep-remote-pipelines-up-to-date.adoc
+++ b/modules/patterns/pages/keep-remote-pipelines-up-to-date.adoc
@@ -63,6 +63,11 @@ This has the added benefits of faster resolution and fewer API requests than oth
 
 === Use git resolver
 
+[WARNING]
+====
+Do not use the git resolver to reference pipelines and tasks that are already in the `+.tekton+` directory of the same repository. Pipelines as Code automatically resolves resources from this directory, so using the git resolver for them is unnecessary and results in additional API requests.
+====
+
 Use the *git resolver* to reference a pipeline that exists in another repository.
 To start referencing a remote Pipeline from a PipelineRun by using the *git resolver*, replace *pipelineSpec* with *pipelineRef*:
 


### PR DESCRIPTION
Including the pipelines and tasks in the `.tekton` directory reduces API requests via PaC's built-in resolver

PaC's resolver "renders" the pipelineruns before creation by resolving pipelineRefs which don't use other resolvers) and replacing your PLR's pipelineRef with a pipelineSpec. If the pipeline referenced by also exists in the .tekton directory, PaC already read the file when scanning for pipelineRuns so it's already in memory and no additional API requests are made.