### PR TITLE
replace task-runner tag+digest to the floating tag

### DIFF
--- a/modules/building/pages/scheduled-builds.adoc
+++ b/modules/building/pages/scheduled-builds.adoc
@@ -114,8 +114,8 @@ spec:
         spec:
           containers:
             - name: trigger-scheduled-build
-              # Find the latest version at https://quay.io/repository/konflux-ci/task-runner?tab=tags
-              image: 'quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f'
+              image: 'quay.io/konflux-ci/task-runner:v1'
+              imagePullPolicy: Always
               command:
                 - /bin/bash
                 - '-c'

--- a/modules/testing/pages/integration/periodic-integration-tests.adoc
+++ b/modules/testing/pages/integration/periodic-integration-tests.adoc
@@ -92,8 +92,8 @@ spec:
         spec:
           containers:
             - name: trigger-e2e-scenario
-              # Find the latest version at https://quay.io/repository/konflux-ci/task-runner?tab=tags
-              image: 'quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f'
+              image: 'quay.io/konflux-ci/task-runner:v1'
+              imagePullPolicy: Always
               command:
                 - /bin/bash
                 - '-c'


### PR DESCRIPTION
When we use tag@digest, users will most likely never update the reference. Replacing it with the floating tag somewhat helps with these problems.

Moreover, I added imagePullPolicy to `Always`, so the job runs always with the newest image (and not with a possibly outdated cached one).