### PR TITLE
fix periodic-integration-tests rbac partial

### DIFF
--- a/modules/testing/pages/integration/periodic-integration-tests.adoc
+++ b/modules/testing/pages/integration/periodic-integration-tests.adoc
@@ -22,9 +22,7 @@ If the Integration Test is designed to only run periodically rather than during 
 
 This procedure details how to grant the necessary snapshot access to a ServiceAccount, which is required to run periodic Integration Tests. It assumes you have an integration test created and a ServiceAccount available in your tenant namespace.
 
-include::partial$integration/periodic-integration-tests-rbac.adoc[]
-
-[start=3]
+include::partial$integration/{context}-periodic-integration-tests-rbac.adoc[]
 
 . Create a CronJob that will trigger a Periodic Integration Test scenario via snaphot labels.
 

--- a/modules/testing/partials/integration/konflux-periodic-integration-tests-rbac.adoc
+++ b/modules/testing/partials/integration/konflux-periodic-integration-tests-rbac.adoc
@@ -40,3 +40,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 
+[start=3]


### PR DESCRIPTION
We want to be able to overwrite the section on how to configure RBAC so that customers can customize that as per their needs.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
