### PR TITLE
add sfowl and swillis0221 to CODEOWNERS for scan results

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,6 +29,9 @@
 /modules/metadata/pages/sboms.adoc  			@konflux-ci/the-collective
 /modules/metadata/partials/sbom*.adoc  			@konflux-ci/the-collective
 
+# Scan Results
+/modules/metadata/pages/scan-results.adoc  			@sfowl @swillis0221
+
 # Vanguard
 /modules/patterns/pages/managing-multiple-versions.adoc			@konflux-ci/vanguard
 


### PR DESCRIPTION
Both myself and Scott are maintainers of https://github.com/konflux-ci/konflux-sast-tasks.

This CODEOWNERS change would help us merge changes like this more quickly: https://github.com/konflux-ci/docs/pull/629