### PR TITLE
docs(STONEINTG-1717): update nudging docs for NudgeConfig CRD

### DIFF
--- a/modules/building/pages/component-nudges.adoc
+++ b/modules/building/pages/component-nudges.adoc
@@ -1,32 +1,17 @@
 = Defining component relationships
-:description: Cross-component relationships so digest updates open automatic PRs.
+:description: Use a NudgeConfig to automatically update image digest references across components after a successful build.
 
-When a tenant namespace includes multiple components, their repositories might contain references to image builds of another component. For example, an application might include multiple child components that, using a Dockerfile `FROM` clause, reference the image build of a common parent. Or, a component might reference image builds from another application altogether. OpenShift operators, for example, often have references to several components across applications.
-
-In such instances, whenever you build a new image of the common parent component, you need to update the references to it. Specifically, you need to copy and paste the pullspec and image digest of that new image to your other source repositories. This process is tedious and error-prone.
-
-However, if you build an application with {ProductName} and make references between components with image digests (`sha256:...`), {ProductName} can automatically generate pull requests to update those references. To use this functionality, simply define the relationships between your components, either in the {ProductName} UI, or in your CLI.
+When a component's repository contains a digest reference to another component's image (for example, a Dockerfile `FROM` clause using `sha256:...`), {ProductName} can automatically open pull requests to keep that reference current after every successful build. To enable this, define the relationship between components using a `NudgeConfig` resource.
 
 [CAUTION]
 ====
-{ProductName} only updates image digest references. If images use tag references, these will not be updated.
+{ProductName} only updates image digest references. Tag-based references are not updated.
 ====
+
 [CAUTION]
 ====
-If image digests are pointing to an architecture-specific link:https://github.com/opencontainers/image-spec/blob/main/manifest.md[Image Manifest], nudging will update the digest to a matching architecture. In order for nudging to update to the digest to an link:https://github.com/opencontainers/image-spec/blob/main/image-index.md[Image Index], the current digest needs to be pointing to an Image Index.
+If image digests point to an architecture-specific link:https://github.com/opencontainers/image-spec/blob/main/manifest.md[Image Manifest], nudging updates the digest to a matching architecture. For nudging to update to an link:https://github.com/opencontainers/image-spec/blob/main/image-index.md[Image Index], the current digest must already point to an Image Index.
 ====
-
-[NOTE]
-====
-By default, {ProductName} only looks for image digest references in Dockerfiles, Containerfiles, and YAML files. However, you can xref:./customizing-the-build.adoc[customize your build pipeline] to adjust that list of files with an annotation on the push PipelineRun definition. This annotation supports a comma-separated list of link:https://docs.renovatebot.com/string-pattern-matching/[regex or glob patterns]. The following annotation would replicate the default behavior.
-====
-
-[source,yaml]
-----
-metadata:
-  annotations:
-    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*"
-----
 
 == In the UI
 
@@ -36,40 +21,32 @@ To define the relationships between components in a tenant namespace, complete t
 
 [NOTE]
 ====
-Currently, applications with only one component do not have the option to define relationships in the UI. To achieve the same result for single-component applications, you can define the relationship in the CLI.
+Currently, applications with only one component do not have the option to define relationships in the UI. To achieve the same result for single-component applications, define the relationship in the CLI.
 ====
-
 
 . Navigate to your application.
 . On any tab, use the *Actions* drop-down menu to select *Define component relationships*.
-.. Alternatively, go to the *Components* tab and select the *Define component relationships*.
+.. Alternatively, go to the *Components* tab and select *Define component relationships*.
 . In the *Component relationships* window, select one component from the *Select a component* drop-down menu.
 . Select *Nudges* or *Is nudged by*, depending on the relationship you want to define.
-
 +
 [NOTE]
 ====
 Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if Component B contains a reference, by image digest, to a build of Component A. After successful push builds of Component A, nudging updates the image digest that Component B references.
 ====
-
-. Use the remaining drop-down menu to choose which other components belong to this relationship.
+. Use the remaining drop-down menu to choose the related components.
 . To define multiple relationships, select *Add another component relationship*.
-. Once you have defined all necessary relationships, select *Save relationships*.
+. Select *Save relationships*.
 
 .Verification
 
-To verify the new relationship in the UI:
-. Go to the *Components* tab for your application.
-. Select a component that belongs to the relationship you defined.
-. Scroll to the end of the page and select *Show related components*.
-
-Alternatively, in the git repo for the component that nudges, push a commit. When the build for that component completes, you should see a new pull request appear for the component that is nudged. This new pull request contains the image digest for the new build of its parent image.
-
+* Go to the *Components* tab, select a component, and scroll to *Show related components*.
+* Push a commit to the nudging component. When the build completes, a pull request should appear in the nudged component's repository containing the new image digest.
 
 .Troubleshooting
 
-* On any tab, use the *Actions* drop-down menu to select *Define component relationships*. If you do not see the relationship, try to define it again and then make sure to select *Save relationships*.
-* Ensure that the existing references in the repositories of your components are correct.
+* If you do not see the relationship, redefine it and make sure to select *Save relationships*.
+* Ensure that the existing references in the component repositories are correct.
 
 == In the CLI
 
@@ -77,117 +54,164 @@ Prerequisites:
 
 * You have completed the steps listed in the xref:ROOT:getting-started.adoc#getting-started-with-the-cli[Getting started in the CLI] page.
 
+Nudge relationships are declared in a `NudgeConfig` resource — one per namespace, always named `nudge-config`. Creating or updating this resource immediately takes effect for subsequent builds.
+
 .Procedure
 
-. In your CLI, xref:ROOT:getting-started.adoc#getting-started-with-the-cli[login] to {ProductName}.
-. List your components, and identify the names of the components you want to relate to each other.
+. Create a file named `nudge-config.yaml` with your nudge relationships:
 +
-`kubectl get components`
+[source,yaml]
+----
+apiVersion: appstudio.redhat.com/v1beta2
+kind: NudgeConfig
+metadata:
+  name: nudge-config          # <1>
+  namespace: <your-namespace>
+spec:
+  nudges:
+    - from: <nudging-component>   # <2>
+      to: <nudged-component>      # <3>
+----
+<1> The name must always be `nudge-config`. There is exactly one `NudgeConfig` per namespace.
+<2> The component whose successful push build triggers the update.
+<3> The component whose repository receives the automated pull request.
 +
-[NOTE]
-====
-Component A _nudges_ Component B (or Component B _is nudged by_ Component A) if Component B contains a reference by image digest to a build of Component A. After successful push builds of Component A, nudging updates the image digest that Component B references.
-====
-. Patch the components to establish the nudging relationship.
+To define multiple relationships, add more entries under `spec.nudges`:
 +
-`kubectl patch components/<name of component that nudges> -p '{"spec":{"build-nudges-ref": ["<name of component that is nudged>"]}}' --type=merge --kubeconfig=<path to kubeconfig>`
+[source,yaml]
+----
+spec:
+  nudges:
+    - from: operator
+      to: bundle
+    - from: operator
+      to: catalog
+----
 
+. Apply the resource:
 +
-NOTE: You can also use **kubectl edit** to add the build-nudges-ref instead of patching the component.
-
-.. You found the names of the two components in the last step.
-.. The `kubeconfig` and its path are the same you used to login to {ProductName}.
+[source,bash]
+----
+kubectl apply -f nudge-config.yaml
+----
 
 .Verification
 
-* Get the component custom resource (CR) definition for the components that nudges. The definition should include a line that says `build-nudges-ref:`, and beneath that, the name of the component that is nudged.
+* Confirm the resource was created:
 +
-`kubectl get components/<name of component that nudges> -o yaml --kubeconfig=<path to kubeconfig> | less`
-* Push a commit to the component that nudges. When the build completes, you should see a new pull request appear for the component that is nudged. This new pull request contains the image digest for the new build of the parent image.
+[source,bash]
+----
+kubectl get nudgeconfig nudge-config -n <your-namespace> -o yaml
+----
 
+* Push a commit to the nudging component. When the build completes, a pull request should appear in the nudged component's repository containing the new image digest.
+
+.Editing relationships
+
+To add or remove nudge relationships, edit the `NudgeConfig` directly and re-apply:
+
+[source,bash]
+----
+kubectl edit nudgeconfig nudge-config -n <your-namespace>
+----
+
+Removing an entry from `spec.nudges` stops that nudge relationship. Adding an entry takes effect on the next push build of that component.
 
 .Troubleshooting
 
-* Ensure that the existing references in the repositories of your components are correct.
-* Try running the necessary commands again, and ensure you have the correct syntax.
+* Ensure that the existing references in the component repositories are correct.
+* Verify that both the `from` and `to` components exist in the namespace: `kubectl get components -n <your-namespace>`
+
+== Validation rules
+
+The following constraints are enforced when you create or update a `NudgeConfig`:
+
+* `from` and `to` must be different — a component cannot nudge itself.
+* The same `(from, to)` pair cannot appear more than once.
+* The nudge graph must contain no cycles — for example, A→B→A is rejected.
+* Both `from` and `to` must be names of existing `Component` resources in the same namespace.
+* `spec.nudges` can contain at most 256 entries.
+* The resource must be named `nudge-config` — only one `NudgeConfig` is allowed per namespace.
 
 == What is nudged
-Only when push pipeline finishes, nudge will be performed (on re-run as well).
 
-When `component1` is nudging `component2`, image which will be nudged is output image from `component1`
-and it will be nudged in the repository of `component2`.
+Nudging is triggered only when a push pipeline run finishes successfully (including re-runs).
 
-Output image is specified in push pipeline run yaml file in param `output-image`
-eg. `quay.io/user-tenant/user-image`.
+When `component1` nudges `component2`, the following image references are updated in `component2`'s repository:
 
-Additionally also image from distribution repositories based on ReleasePlanAdmission will be nudged as well,
-for that to work ReleasePlanAdmission has to exist and contain:
+* The **output image** from `component1`'s push pipeline run (the `output-image` param, for example `quay.io/user-tenant/user-image`).
+* Images from **distribution repositories** defined in a `ReleasePlanAdmission`, if the admission includes a mapping for the nudging component:
++
 [source,yaml]
---
+----
 spec:
   data:
     mapping:
       components:
         - name: component1
           repository: quay.io/some-org/released-image
---
-Where component name has to be the same as nudging component eg. `component1`.
+----
++
+In this case both `quay.io/user-tenant/user-image` and `quay.io/some-org/released-image` are updated.
 
-In such case both image references will be nudged:
+A nudging pull request is created in a branch named:
+`konflux/component-updates/NUDGED_COMPONENT-component-update-NUDGING_COMPONENT`
 
-- `quay.io/user-tenant/user-image`
-- `quay.io/some-org/released-image`
-
-When a component has multiple components in `spec.build-nudges-ref`, it nudges all of them.
-A nudging pull request is created by default in a branch named
-`konflux/component-updates/NUDGED_COMPONENT-component-update-NUDGING_COMPONENT`.
-
-If you nudge multiple components that are in the same repository and branch,
-multiple pull requests are created with identical changes. To prevent this,
-add the `build.appstudio.openshift.io/build-nudge-simple-branch: 'true'` annotation
-to all affected components. This changes the branch name for the nudging pull request
-to `konflux/component-updates/component-update-NUDGING_COMPONENT`, resulting in a single
-pull request because Renovate can only create one branch with that name.
-
-== Customizing nudging PRs
-Nudging feature is using renovate `https://docs.renovatebot.com/` to actually do the job,
-for which you can customize some options specified in ConfigMap in your namespace.
-
-Only following options are possible to customize via ConfigMap (for more details about those options refer to `https://docs.renovatebot.com/`.):
-
-* automerge
-* automergeType
-* commitMessagePrefix
-* commitMessageSuffix
-* fileMatch (',' comma is separator)
-* ignoreTests
-* platformAutomerge
-* gitLabIgnoreApprovals
-* automergeSchedule (';' semicolon is separator)
-* labels (',' comma is separator)
-
-
-.There are two possible ways to customize:
-. Create namespace wide config in ConfigMap named *`namespace-wide-nudging-renovate-config`* (*the name is mandatory*)
-which will be used for all nudged components in your namespace, unless component specific config exists.
-. Create config for specific nudged component in ConfigMap in your namespace and add annotation `build.appstudio.openshift.io/nudge_renovate_config_map` to the component with value of ConfigMap name and
-it will be used for the component in your namespace.
-
-Both ConfigMaps have the same format, where keys are allowed options in the list above, values
-are always strings, so in case option is boolean, you will have to specify "true" or "false".
-
-When you have either of ConfigMaps, nudging default renovate config will use additionally options from your ConfigMap.
-
-.ConfigMap Example
+If you nudge multiple components that share the same repository and branch, add the following annotation to all affected components to consolidate into a single pull request:
 
 [source,yaml]
---
----
+----
+metadata:
+  annotations:
+    build.appstudio.openshift.io/build-nudge-simple-branch: 'true'
+----
+
+=== Controlling which files are scanned
+
+By default, {ProductName} scans Dockerfiles, Containerfiles, and YAML files for image digest references. Override this per pipeline run with an annotation on the push PipelineRun definition:
+
+[source,yaml]
+----
+metadata:
+  annotations:
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*"
+----
+
+This annotation supports a comma-separated list of link:https://docs.renovatebot.com/string-pattern-matching/[regex or glob patterns].
+
+== Customizing nudging PRs
+
+Nudging uses link:https://docs.renovatebot.com/[Renovate] to open pull requests. You can customize its behavior with a ConfigMap in your namespace.
+
+The following options are configurable:
+
+* `automerge`
+* `automergeType`
+* `commitMessagePrefix`
+* `commitMessageSuffix`
+* `fileMatch` (comma-separated)
+* `ignoreTests`
+* `platformAutomerge`
+* `gitLabIgnoreApprovals`
+* `automergeSchedule` (semicolon-separated)
+* `labels` (comma-separated)
+
+There are two scopes:
+
+. *Namespace-wide:* Create a ConfigMap named `namespace-wide-nudging-renovate-config`. This applies to all nudged components in the namespace unless a component-specific ConfigMap exists.
+. *Per-component:* Create a ConfigMap with any name and add the annotation `build.appstudio.openshift.io/nudge_renovate_config_map: <configmap-name>` to the nudged component.
+
+All values must be strings. For boolean options, use `"true"` or `"false"`.
+
+.ConfigMap example
+
+[source,yaml]
+----
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: namespace-wide-nudging-renovate-config
-  namespace: <namespace>
+  namespace: <your-namespace>
 data:
   automerge: "true"
   automergeType: "pr"
@@ -197,7 +221,6 @@ data:
   ignoreTests: "true"
   gitLabIgnoreApprovals: "true"
   platformAutomerge: "true"
-  # eventually set `platformAutomerge: "false"` and configure your own schedule
   # automergeSchedule: "* 22-23,0-4 * * *; * * * * 0,6"
   labels: "customLabel1, customLabel2"
---
+----

--- a/modules/end-to-end/pages/building-olm.adoc
+++ b/modules/end-to-end/pages/building-olm.adoc
@@ -40,7 +40,7 @@ In order to enable your operator to be installed in disconnected environments, i
 
 . In the {ProductName} UI, in your OLM Operator's application, go to the *Components* tab and copy the URL for the Operator's container image. The URL should include `sha256:`.
 . Using your preferred text editor, in the git repo for your OLM Operator, open the CSV file for your bundle. In that file, update the image reference to the Operator to be the URL you just copied. Commit this change.
-. In the {ProductName} UI, follow the instructions in xref:building:/component-nudges.adoc[this document] to define the relationship between the Operator and the bundle. The Operator nudges the bundle.
+. Follow the instructions in xref:building:component-nudges.adoc[Defining component relationships] to configure the Operator to nudge the bundle.
 . (Optional) For any Operands with image references in your bundle's CSV, you can repeat this same basic process:
 .. Add the Operands as components in {ProductName}.
 .. Wait for the first build of those components to finish.

--- a/modules/reference/pages/kube-apis/application-api.adoc
+++ b/modules/reference/pages/kube-apis/application-api.adoc
@@ -1,4 +1,5 @@
 // Generated documentation. Please do not edit.
+// NOTE: The appstudio.redhat.com/v1beta2 section (NudgeConfig) below is manually maintained.
 :anchor_prefix: k8s-api
 
 [id="reference"]
@@ -6,6 +7,7 @@
 
 .Packages
 - xref:{anchor_prefix}-appstudio-redhat-com-v1alpha1[$$appstudio.redhat.com/v1alpha1$$]
+- xref:{anchor_prefix}-appstudio-redhat-com-v1beta2[$$appstudio.redhat.com/v1beta2$$]
 
 
 [id="{anchor_prefix}-appstudio-redhat-com-v1alpha1"]
@@ -556,9 +558,9 @@ Optional. + |  |
 | *`skipGitOpsResourceGeneration`* __boolean__ | Whether or not to bypass the generation of GitOps resources for the Component. Defaults to false. +
 Optional. +
 !!! Will be removed when we remove old model + |  |
-| *`build-nudges-ref`* __string array__ | The list of components to be nudged by this components build upon a successful result. +
-Optional. +
-!!! Will be removed when we remove old model + |  |
+| *`build-nudges-ref`* __string array__ | *Deprecated.* Use xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfig[$$NudgeConfig$$] instead. +
+The list of components to be nudged by this component's build upon a successful result. +
+Optional. + |  |
 | *`actions`* __xref:{anchor_prefix}-github-com-konflux-ci-application-api-api-v1alpha1-componentactions[$$ComponentActions$$]__ | Specific actions that will be processed by the controller and then removed from 'spec.actions'. +
 Used for triggering builds or creating pipeline configuration PRs. +
 Optional. + |  |
@@ -605,8 +607,8 @@ Example: 41fbdb124775323f58fd5ce93c70bb7d79c20650. +
 | *`lastPromotedImage`* __string__ | The last digest image component promoted with. +
 Example: quay.io/someorg/somerepository@sha256:5ca85b7f7b9da18a9c4101e81ee1d9bac35ac2b0b0221908ff7389204660a262. +
 !!! Will be removed when we remove old model SHOULD this be in version specific section?? + |  |
-| *`build-nudged-by`* __string array__ | The list of names of Components whose builds nudge this resource (their spec.build-nudges-ref[] references this component) +
-!!! Will be removed when we remove old model + |  |
+| *`build-nudged-by`* __string array__ | *Deprecated.* The list of names of Components whose builds nudge this resource. +
+Populated from the legacy `spec.build-nudges-ref` field. Use xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfig[$$NudgeConfig$$] instead. + |  |
 | *`repository-settings`* __xref:{anchor_prefix}-github-com-konflux-ci-application-api-api-v1alpha1-repositorysettings[$$RepositorySettings$$]__ | Identifies which additional settings are used for the Repository CR. + |  |
 | *`message`* __string__ | General error message, not specific to any version (version-specific errors are in versions[].message). +
 Example: "spec.containerImage is not set" or "GitHub App is not installed". + |  |
@@ -856,6 +858,124 @@ Required. + |  |
 Optional. + |  |
 | *`github-app-token-scope-repos`* __string array__ | When specified, will add values to `github_app_token_scope_repos` in the Repository CR +
 Optional. + |  |
+|===
+
+
+[id="{anchor_prefix}-appstudio-redhat-com-v1beta2"]
+=== appstudio.redhat.com/v1beta2
+
+Package v1beta2 contains API Schema definitions for the appstudio v1beta2 API group
+
+.Resource Types
+- xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfig[$$NudgeConfig$$]
+
+
+[id="{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfig"]
+==== NudgeConfig
+
+NudgeConfig is a namespace-scoped singleton resource that declares component nudging relationships.
+Exactly one `NudgeConfig` named `nudge-config` may exist per namespace.
+Structural and singleton constraints are enforced by the API server; cycle detection and Component existence are enforced by a validating webhook.
+
+See xref:building:component-nudges.adoc[Defining component relationships] for usage instructions.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfiglist[$$NudgeConfigList$$]
+****
+
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+| *`apiVersion`* __string__ | `appstudio.redhat.com/v1beta2` | |
+| *`kind`* __string__ | `NudgeConfig` | |
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`. The `metadata.name` must be `nudge-config`. | |
+| *`spec`* __xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfigspec[$$NudgeConfigSpec$$]__ | | |
+| *`status`* __xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfigstatus[$$NudgeConfigStatus$$]__ | | |
+|===
+
+
+[id="{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfigspec"]
+==== NudgeConfigSpec
+
+NudgeConfigSpec defines the desired nudging relationships between components.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfig[$$NudgeConfig$$]
+****
+
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+| *`nudges`* __xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgerelationship[$$NudgeRelationship$$] array__ | The list of component nudge relationships. +
+Optional. + | | MaxItems: 256
+|===
+
+
+[id="{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgerelationship"]
+==== NudgeRelationship
+
+NudgeRelationship defines a single nudge from one component to another.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfigspec[$$NudgeConfigSpec$$]
+****
+
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+| *`from`* __string__ | The source component name. A successful push build of this component triggers the nudge. +
+Required. + | | MinLength: 1 +
+MaxLength: 63 +
+Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+| *`to`* __string__ | The target component name. This component's repository receives the automated pull request. +
+Required. + | | MinLength: 1 +
+MaxLength: 63 +
+Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+| *`mode`* __xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgemodetype[$$NudgeModeType$$]__ | When the nudge is triggered. `immediate` triggers on build success; `validated` triggers after integration tests pass. +
+Optional. + | `immediate` | Enum: `immediate`, `validated`
+|===
+
+
+[id="{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgemodetype"]
+==== NudgeModeType
+
+_Underlying type:_ _string_
+
+NudgeModeType defines when a nudge is triggered.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgerelationship[$$NudgeRelationship$$]
+****
+
+[cols="20a,50a", options="header"]
+|===
+| Value | Description
+| `immediate` | Trigger the nudge as soon as the source component build succeeds.
+| `validated` | Trigger the nudge only after integration tests pass for the source component.
+|===
+
+
+[id="{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfigstatus"]
+==== NudgeConfigStatus
+
+NudgeConfigStatus defines the observed state of NudgeConfig.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-appstudio-redhat-com-v1beta2-nudgeconfig[$$NudgeConfig$$]
+****
+
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+| *`conditions`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#condition-v1-meta[$$Condition$$] array__ | Conditions represent the latest available observations of the NudgeConfig's state. Includes a `StaleReferences` condition that is set to `True` when any `from` or `to` component no longer exists in the namespace. +
+Optional. + | |
+| *`lastValidationTime`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#time-v1-meta[$$Time$$]__ | Timestamp of the last successful validation of the nudge graph. +
+Optional. + | |
 |===
 
 


### PR DESCRIPTION
Rewrote CLI section in component-nudges.adoc to use NudgeConfig CRD
 instead of kubectl patch spec.build-nudges-ref
Added validation rules section documenting webhook constraints Added editing/removing relationships instructions
Marked build-nudges-ref and build-nudged-by as deprecated in
 application-api.adoc; added full NudgeConfig v1beta2 API reference
Updated building-olm.adoc nudge step to not be UI-specific


more info in [STONEINTG-1717](https://redhat.atlassian.net/browse/STONEINTG-1717)
Assisted-By: Claude code 4.6

[STONEINTG-1717]: https://redhat.atlassian.net/browse/STONEINTG-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ