### PR TITLE
STONEBLD-4926 docs: add task documentation page generated from build-pipeline-tasks

### DIFF
--- a/hack/gen-build-tasks-docs.sh
+++ b/hack/gen-build-tasks-docs.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+
+set -e
+
+repo_root="$(pwd)"
+dest="${repo_root}/modules/building/pages/task-documentation.adoc"
+repo="container-build-catalog"
+genSrc="$(mktemp -d /tmp/container-build-catalog.XXXXXX)"
+trap 'rm -rf "${genSrc}"' EXIT
+
+pushd "${genSrc}"
+
+git clone --depth 1 "https://github.com/konflux-ci/${repo}.git" "${repo}"
+
+cat > "${dest}" <<'EOF'
+= Task documentation
+:description: Reference of Tekton tasks from the konflux-ci/container-build-catalog repository.
+
+// Generated documentation. Please do not edit.
+// Run: npm run gen-build-tasks-docs
+
+This page lists Tekton tasks defined in
+link:https://github.com/konflux-ci/container-build-catalog/tree/main/task[container-build-catalog/task].
+
+[cols="2,3", options="header"]
+|===
+| Task | Documentation
+EOF
+
+# One row per task that has a README (layout: task/<name>/README.md)
+for readme in "${repo}"/task/*/README.md; do
+    [ -f "${readme}" ] || continue
+
+    name="$(basename "$(dirname "${readme}")")"
+    url="https://github.com/konflux-ci/container-build-catalog/blob/main/task/${name}/README.md"
+    echo "| \`${name}\` | link:${url}[Task README]" >> "${dest}"
+done
+
+echo "|===" >> "${dest}"
+
+popd
+echo "Wrote ${dest}"

--- a/modules/building/nav.adoc
+++ b/modules/building/nav.adoc
@@ -13,6 +13,7 @@
 *** xref:imagerepository.adoc[Customizing ImageRepository]
 *** xref:labels-and-annotations.adoc[Using labels and annotations]
 *** xref:build-with-args.adoc[Passing buildah arguments]
+*** xref:task-documentation.adoc[Task documentation]
 ** Secrets
 *** xref:secrets/index.adoc[Creating secrets for your builds]
 **** xref:secrets/creating-task-input-secrets.adoc[Creating task input secrets]

--- a/modules/building/pages/task-documentation.adoc
+++ b/modules/building/pages/task-documentation.adoc
@@ -1,0 +1,32 @@
+= Task documentation
+:description: Reference of Tekton tasks from the konflux-ci/container-build-catalog repository.
+
+// Generated documentation. Please do not edit.
+// Run: npm run gen-build-tasks-docs
+
+This page lists Tekton tasks defined in
+link:https://github.com/konflux-ci/container-build-catalog/tree/main/task[container-build-catalog/task].
+
+[cols="2,3", options="header"]
+|===
+| Task | Documentation
+| `apply-tags` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/apply-tags/README.md[Task README]
+| `build-image-index-min` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/build-image-index-min/README.md[Task README]
+| `build-image-index` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/build-image-index/README.md[Task README]
+| `buildah-oci-ta-min` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah-oci-ta-min/README.md[Task README]
+| `buildah-oci-ta` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah-oci-ta/README.md[Task README]
+| `buildah-remote-oci-ta` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah-remote-oci-ta/README.md[Task README]
+| `buildah-remote` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah-remote/README.md[Task README]
+| `buildah` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah/README.md[Task README]
+| `git-clone-oci-ta-min` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/git-clone-oci-ta-min/README.md[Task README]
+| `git-clone-oci-ta` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/git-clone-oci-ta/README.md[Task README]
+| `git-clone` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/git-clone/README.md[Task README]
+| `init` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/init/README.md[Task README]
+| `prefetch-dependencies-oci-ta-min` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/prefetch-dependencies-oci-ta-min/README.md[Task README]
+| `prefetch-dependencies-oci-ta` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/prefetch-dependencies-oci-ta/README.md[Task README]
+| `prefetch-dependencies` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/prefetch-dependencies/README.md[Task README]
+| `push-dockerfile-oci-ta` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/push-dockerfile-oci-ta/README.md[Task README]
+| `push-dockerfile` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/push-dockerfile/README.md[Task README]
+| `source-build-oci-ta` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/source-build-oci-ta/README.md[Task README]
+| `source-build` | link:https://github.com/konflux-ci/container-build-catalog/blob/main/task/source-build/README.md[Task README]
+|===

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "api-gen": "./hack/gen-api-docs.sh",
+    "gen-build-tasks-docs": "./hack/gen-build-tasks-docs.sh",
     "build": "antora generate --clean --fetch antora-playbook.yml",
     "generate-llms-txt": "bash hack/generate-llms-txt.sh public/llms.txt",
     "preview:netlify": "netlify deploy --dir public",


### PR DESCRIPTION
## Summary
- Add a Task documentation page under Building → Build configuration that lists the latest version of each task from [container-build-catalog/task](https://github.com/konflux-ci/container-build-catalog), with links to their READMEs
- Add `hack/gen-task-docs.sh` and `npm run task-gen` to regenerate the page

Closes [STONEBLD-4926](https://redhat.atlassian.net/browse/STONEBLD-4926)

[STONEBLD-4926]: https://redhat.atlassian.net/browse/STONEBLD-4926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ