### PR TITLE
Add CVE image tool to security updates documentation

### DIFF
--- a/modules/mintmaker/pages/security-updates.adoc
+++ b/modules/mintmaker/pages/security-updates.adoc
@@ -15,4 +15,4 @@ The CVE data is provided by Red Hat. The https://github.com/konflux-ci/mintmaker
 and includes CVE data up to 120 days old.
 
 A community tool https://github.com/os-observability/konflux-opentelemetry/tree/main/tools/image-cve-check[image-cve-check] was created, which can help to check
-for active CVEs in images built on Konflux and verify if a CVE was fixed by the updated RPM package in in the lock file.
+for active CVEs in images built on Konflux and verify if a CVE was fixed by the updated RPM package in the lock file.

--- a/modules/mintmaker/pages/security-updates.adoc
+++ b/modules/mintmaker/pages/security-updates.adoc
@@ -13,3 +13,6 @@ on their severity.
 
 The CVE data is provided by Red Hat. The https://github.com/konflux-ci/mintmaker-osv-database[database] that MintMaker uses is rebuilt every hour
 and includes CVE data up to 120 days old.
+
+A community tool https://github.com/os-observability/konflux-opentelemetry/tree/main/tools/image-cve-check[image-cve-check] was created, which can help to check
+for active CVEs in images built on Konflux and verify if a CVE was fixed by the updated RPM package in in the lock file.


### PR DESCRIPTION
Added information about a community tool for checking CVEs in images built on Konflux.


Add link to https://github.com/os-observability/konflux-opentelemetry/tree/main/tools/image-cve-check which we use for CVE investigation and mintmaker rpm.lock file checks.

When `--lockfile` is specified it checks if the package was updated in the lockfile and mentions it in the report.