### PR TITLE
Update guidance on creating service accounts for accessing private registries

### DIFF
--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -107,23 +107,9 @@ metadata:
 
 . Create a service account token secret:
 +
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: external-puller-token
-  namespace: <your-namespace>
-  annotations:
-    kubernetes.io/service-account.name: konflux-bot-[0-9]
-type: kubernetes.io/service-account-token
-----
-
-. Get the service account token from the secret:
-+
 [source,bash]
 ----
-kubectl get secret external-puller-token -n <your-namespace> -o jsonpath='{.data.token}' | base64 -d
+oc create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h
 ----
 
 . Use the token to authenticate to the registry in your external system:

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -58,7 +58,10 @@ subjects:
 ** Tokens are only issued to service accounts named according to the pattern `konflux-bot-[0-9]` (e.g. `konflux-bot-0`, `konflux-bot-1`, etc)
 ** Any Konflux user who has permission to create service accounts in a namespace can create a `konflux-bot-[0-9]` service account
 ** ClusterRoles of the pattern `konflux-*-bot-actions` can be assigned to the service accounts
-*** Two are currently available: link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml[konflux-releaser-bot-actions] and link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml[konflux-builder-bot-actions]
+*** Three are currently available: 
+**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml[konflux-releaser-bot-actions]
+**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml[konflux-builder-bot-actions]
+**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-externalpuller-bot-actions.yaml[konflux-externalpuller-bot-actions]
 ** Tokens can be minted with `oc create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h`
 ** `--duration` must be specified and can be any value up to 1 year (8760 hours). Users are encouraged to specify the shortest feasible duration
 ** Can authenticate against both the proxy AND the OpenShift API (works like a regular OpenShift service account)
@@ -98,7 +101,7 @@ For automated access in external systems like Testing Farm or CI/CD pipelines:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: external-puller
+  name: konflux-bot-[0-9]
   namespace: <your-namespace>
 ----
 
@@ -112,7 +115,7 @@ metadata:
   name: external-puller-token
   namespace: <your-namespace>
   annotations:
-    kubernetes.io/service-account.name: external-puller
+    kubernetes.io/service-account.name: konflux-bot-[0-9]
 type: kubernetes.io/service-account-token
 ----
 
@@ -127,7 +130,7 @@ kubectl get secret external-puller-token -n <your-namespace> -o jsonpath='{.data
 +
 [source,bash]
 ----
-podman login -u external-puller image-rbac-proxy.apps.example.com
+podman login -u konflux-bot-[0-9] image-rbac-proxy.apps.example.com
 # When prompted for password, paste the service account token
 ----
 +

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -55,10 +55,15 @@ subjects:
 ** Best for local development and manual testing
 
 * *Service account tokens*:
-** Any Konflux user who has permission to create secrets in a namespace can create a service account token in that namespace
+** Tokens are only issued to service accounts named according to the pattern `konflux-bot-[0-9]` (e.g. `konflux-bot-0`, `konflux-bot-1`, etc)
+** Any Konflux user who has permission to create service accounts in a namespace can create a `konflux-bot-[0-9]` service account
+** ClusterRoles of the pattern `konflux-*-bot-actions` can be assigned to the service accounts
+*** Two are currently available: link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml[konflux-releaser-bot-actions] and link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml[konflux-builder-bot-actions]
+** Tokens can be minted with `oc create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h`
+** `--duration` must be specified and can be any value up to 1 year (8760 hours). Users are encouraged to specify the shortest feasible duration
 ** Can authenticate against both the proxy AND the OpenShift API (works like a regular OpenShift service account)
-** Do not expire (valid until the secret is deleted)
 ** Best for automated systems and CI/CD pipelines
+** Exceptions to the 10-SA-per-namespace limit are considered on a case-by-case basis
 
 == Getting registry login credentials via UI
 

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -62,7 +62,9 @@ subjects:
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml[konflux-releaser-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml[konflux-builder-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-externalpuller-bot-actions.yaml[konflux-externalpuller-bot-actions]
-** Tokens can be minted with `kubectl create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h`
+** Tokens can be minted with 
+[source, bash]
+kubectl create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h
 ** `--duration` must be specified and can be any value up to 1 year (8760 hours). Users are encouraged to specify the shortest feasible duration
 ** Can authenticate against both the proxy AND the OpenShift API (works like a regular OpenShift service account)
 ** Best for automated systems and CI/CD pipelines

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -62,7 +62,7 @@ subjects:
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml[konflux-releaser-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml[konflux-builder-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-externalpuller-bot-actions.yaml[konflux-externalpuller-bot-actions]
-** Tokens can be minted with `oc create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h`
+** Tokens can be minted with `kubectl create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h`
 ** `--duration` must be specified and can be any value up to 1 year (8760 hours). Users are encouraged to specify the shortest feasible duration
 ** Can authenticate against both the proxy AND the OpenShift API (works like a regular OpenShift service account)
 ** Best for automated systems and CI/CD pipelines
@@ -109,7 +109,7 @@ metadata:
 +
 [source,bash]
 ----
-oc create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h
+kubectl create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h
 ----
 
 . Use the token to authenticate to the registry in your external system:

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -57,18 +57,21 @@ subjects:
 * *Service account tokens*:
 ** Tokens are only issued to service accounts named according to the pattern `konflux-bot-[0-9]` (e.g. `konflux-bot-0`, `konflux-bot-1`, etc)
 ** Any Konflux user who has permission to create service accounts in a namespace can create a `konflux-bot-[0-9]` service account
-** ClusterRoles of the pattern `konflux-*-bot-actions` can be assigned to the service accounts
-*** Three are currently available: 
+** Only ClusterRoles of the pattern `konflux-*-bot-actions` can be assigned to the service accounts, and  when assigning roles, service accounts should follow the principle of least privilege
+***  The following roles are available: 
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml[konflux-releaser-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml[konflux-builder-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-externalpuller-bot-actions.yaml[konflux-externalpuller-bot-actions]
-** Tokens can be minted with 
+**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-integrationtest-bot-actions.yaml[konflux-integrationtest-bot-actions]
+**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-model-bot-actions.yaml[konflux-model-bot-actions]
+**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-secrets-bot-actions.yaml[konflux-secrets-bot-actions]
+**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-viewer-bot-actions.yaml[konflux-viewer-bot-actions]
+** Only users with the role `konflux-admin-user-actions` can mint tokens. Assuming an SA named `konflux-bot-0`, tokens can then be minted with 
 [source, bash]
-kubectl create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h
+oc create token konflux-bot-0 -n <your-namespace> --duration=8760h
 ** `--duration` must be specified and can be any value up to 1 year (8760 hours). Users are encouraged to specify the shortest feasible duration
 ** Can authenticate against both the proxy AND the OpenShift API (works like a regular OpenShift service account)
 ** Best for automated systems and CI/CD pipelines
-** Exceptions to the 10-SA-per-namespace limit are considered on a case-by-case basis
 
 == Getting registry login credentials via UI
 
@@ -103,7 +106,7 @@ For automated access in external systems like Testing Farm or CI/CD pipelines:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: konflux-bot-[0-9]
+  name: konflux-bot-0 # can be any number 0-9
   namespace: <your-namespace>
 ----
 
@@ -111,7 +114,7 @@ metadata:
 +
 [source,bash]
 ----
-kubectl create token konflux-bot-<bot-number> -n <your-namespace> --duration=8760h
+oc create token konflux-bot-0 -n <your-namespace> --duration=8760h
 ----
 
 . Use the token to authenticate to the registry in your external system:

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -107,7 +107,7 @@ metadata:
   namespace: <your-namespace>
 ----
 
-. Create a service account token secret:
+. Create a service account token:
 +
 [source,bash]
 ----

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -64,7 +64,6 @@ subjects:
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-externalpuller-bot-actions.yaml[konflux-externalpuller-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-integrationtest-bot-actions.yaml[konflux-integrationtest-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-model-bot-actions.yaml[konflux-model-bot-actions]
-**** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-secrets-bot-actions.yaml[konflux-secrets-bot-actions]
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-viewer-bot-actions.yaml[konflux-viewer-bot-actions]
 ** Only users with the role `konflux-admin-user-actions` can mint tokens. Assuming an SA named `konflux-bot-0`, tokens can then be minted with 
 [source, bash]

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -55,8 +55,8 @@ subjects:
 ** Best for local development and manual testing
 
 * *Service account tokens*:
-** Tokens are only issued to service accounts named according to the pattern `konflux-bot-[0-9]` (e.g. `konflux-bot-0`, `konflux-bot-1`, etc)
-** Any Konflux user who has permission to create service accounts in a namespace can create a `konflux-bot-[0-9]` service account
+** Tokens are only issued to a maximum of three service accounts per namespace, named according to the pattern `konflux-bot-[0-2]` (e.g. `konflux-bot-0`, `konflux-bot-1`, or `konflux-bot-2`)
+** Any Konflux user who has permission to create service accounts in a namespace can create a `konflux-bot-[0-2]` service account
 ** Only ClusterRoles of the pattern `konflux-*-bot-actions` can be assigned to the service accounts, and  when assigning roles, service accounts should follow the principle of least privilege
 ***  The following roles are available: 
 **** link:https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml[konflux-releaser-bot-actions]

--- a/modules/building/pages/accessing-private-images.adoc
+++ b/modules/building/pages/accessing-private-images.adoc
@@ -121,7 +121,7 @@ oc create token konflux-bot-0 -n <your-namespace> --duration=8760h
 +
 [source,bash]
 ----
-podman login -u konflux-bot-[0-9] image-rbac-proxy.apps.example.com
+podman login -u konflux-bot-0 image-rbac-proxy.apps.example.com
 # When prompted for password, paste the service account token
 ----
 +


### PR DESCRIPTION
**Summary**
 Documents that tokens are only issued to service accounts matching the naming pattern konflux-bot-[0-2] (e.g. konflux-bot-0, konflux-bot-1).

**Changes**
- Clarifies that any user with permission to create service accounts in a namespace can create a konflux-bot-[0-2] service account.
- Adds guidance on assigning konflux-*-bot-actions ClusterRoles, and links the two currently available roles (konflux-releaser-bot-actions and konflux-builder-bot-actions).
- Provides the oc create token command for minting tokens, and explains the required --duration flag (up to 1 year / 8760 hours), encouraging the shortest feasible duration.
- Notes the 3-service-account-per-namespace limit and that exceptions are handled case-by-case.
- Removes the now-inaccurate statement that tokens do not expire.

**Motivation**

The previous guidance was out of date: it stated that service account tokens do not expire and omitted the naming-pattern requirement, the ClusterRole assignments, and the token-duration constraints that users now need to follow.

EDIT: Number of allowed SAs per namespace has been reduced to 3