### PR TITLE
doc(RELEASE-2682): add docs for managed pipeline retries

### DIFF
--- a/modules/releasing/nav.adoc
+++ b/modules/releasing/nav.adoc
@@ -4,5 +4,6 @@
 ** xref:create-release.adoc[Creating a release]
 ** xref:retrigger-release.adoc[Re-trigger a release manually]
 ** xref:tenant-release-pipelines.adoc[Tenant Release Pipelines]
+** xref:managed-pipeline-retries.adoc[Managed pipeline automatic retries]
 ** xref:adjusting-timeouts-resources.adoc[Adjusting timeouts and resources]
 ** xref:using-collectors.adoc[Using collectors]

--- a/modules/releasing/pages/adjusting-timeouts-resources.adoc
+++ b/modules/releasing/pages/adjusting-timeouts-resources.adoc
@@ -33,13 +33,17 @@ pipeline:
 
 IMPORTANT: Tekton enforces a restriction on the pipeline timeout—it must be greater than or equal to the sum of the timeouts for tasks and finally.
 
+IMPORTANT: If your Pipeline is configured for xref:managed-pipeline-retries.adoc[automatic retries] any `timeouts`
+you set in your RPA for the Managed Pipeline become the base that is increased by the mitigation increment on each
+retry, instead of the default.
+
 == Adjust resources
 
 Release Pipelines are configured with default CPU and memory values for each Task and Step. These defaults are based on testing with typical workloads and are
 refined over time using user feedback. However, some Releases contain a larger than average number of Components, which can cause certain Tasks or
 Steps to exceed the default resources and fail, often due to `OOMKilled` errors.
 
-Increasing resources globally for every user would waste cluster resources, so {ProductName} 
+Increasing resources globally for every user would waste cluster resources, so {ProductName}
 supports per Release resource overrides using `taskRunSpecs`.
 
 NOTE: {ProductName} is exploring future improvements to make resource allocation more dynamic,
@@ -47,14 +51,18 @@ for example by tuning defaults based on the number of Components.
 
 == Understand taskRunSpecs
 
-`taskRunSpecs` allow you to override compute resources *at runtime* for a specific Task or Step without 
-modifying the underlying Pipeline or Task definitions. They are defined in the `pipeline` section of 
+`taskRunSpecs` allow you to override compute resources *at runtime* for a specific Task or Step without
+modifying the underlying Pipeline or Task definitions. They are defined in the `pipeline` section of
 a `ReleasePlanAdmission` and apply to any Release execution that uses the `ReleasePlanAdmission`.
 
 Use `taskRunSpecs` when:
 
 * A Task fails with `OOMKilled` errors
 * The Release has an unusually large number of Components
+
+IMPORTANT: If your Pipeline is configured for xref:managed-pipeline-retries.adoc[automatic retries] any
+`computeResources` you set in your RPA for the Managed Pipeline become the base that is multiplied by the
+mitigation multiplier on each retry, instead of the default.
 
 == Task-level vs Step-level overrides
 
@@ -107,7 +115,7 @@ Releases use pipelines stored in the https://github.com/konflux-ci/release-servi
 
 === Find the `pipelineTaskName`
 
-Open the Pipeline definition in the repository on the specified branch at the 
+Open the Pipeline definition in the repository on the specified branch at the
 `pathInRepo` location and inspect the `tasks` section.
 
 [source,yaml]
@@ -198,7 +206,7 @@ spec:
 === Step-level override example (recommended)
 
 The following example shows a `ReleasePlanAdmission` with a step-level
-resource override. Only the `validate` Step in the `verify-conforma` Task will 
+resource override. Only the `validate` Step in the `verify-conforma` Task will
 receive the override resources. Other Steps will keep their default compute resources.
 
 [source,yaml]

--- a/modules/releasing/pages/managed-pipeline-retries.adoc
+++ b/modules/releasing/pages/managed-pipeline-retries.adoc
@@ -1,0 +1,126 @@
+= Managed pipeline automatic retries
+:description: Automatic retries for Managed Pipelines and how to check and override retry behavior on a ReleasePlanAdmission.
+
+A Managed Pipeline can fail for reasons that have nothing to do with the content being released, such as a Task
+running out of memory. Re-running the Pipeline with more memory or more time is often enough for the Release to
+succeed. {ProductName} does this automatically. When a Managed Pipeline fails for these reasons, it retries the
+Pipeline multiplying memory or increasing timeouts for the retry attempt.
+
+Automatic retries are managed by {ProductName} and are not user defined. From your ReleasePlanAdmission (RPA) you
+can check whether retries are active for your Managed Pipeline and adjust how many retries are allowed.
+
+== Check if your pipeline is configured for retries
+
+Check your RPA's status to see whether retries are active for your Managed Pipeline:
+
+[source,shell]
+----
+$ kubectl get releaseplanadmission <rpa-name> -n <managed-tenant-namespace> -o yaml
+----
+
+Look for the `retryInfo` field under `status`:
+
+[source,yaml]
+----
+status:
+  retryInfo:
+    enabled: true <.>
+    maxRetries: 3 <.>
+    reason: retries enabled by policy <.>
+----
+
+<.> Whether automatic retries are active for this RPA's Managed Pipeline.
+<.> The number of retry attempts that will be made after the initial Pipeline fails.
+<.> A short explanation of the result, for example `pipeline not configured for retries`, `retries disabled by RPA
+pipeline override`, or `disabled by tag: <tag>` when a tag on the release is blocking retries.
+
+If retries aren't configured for the Managed Pipeline, `retryInfo` will show:
+
+[source,yaml]
+----
+status:
+  retryInfo:
+    enabled: false
+    reason: pipeline not configured for retries
+----
+
+You can also see the outcome of each attempt on the `Release` CR itself, under `status.managedPipelineAttempts`.
+Every attempt records which PipelineRun ran. If it failed it also includes the failure reason, mitigations,
+and the last Task and Step that were running.
+
+== Understand which failures trigger a retry
+
+Not every failure is retried. Retrying a genuine error is unlikely to make a Release succeed. {ProductName}
+only retries a Managed Pipeline for failures that can be fixed with more resources or time. The following
+failure reasons trigger a retry:
+
+* `OOMKill`: A Task or Step was killed for exceeding its memory limit.
+* `PipelineRunTimeout`: The overall PipelineRun didn't finish within its timeout.
+* `TaskRunTimeout`: An individual TaskRun didn't finish within its timeout.
+
+An `Error` failure is never retried automatically.
+
+== Override the retry count
+
+If your Pipeline is configured for retries, you can override how many attempts are allowed by setting `maxRetries`
+on the `pipeline` field of your RPA:
+
+[source,yaml]
+----
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: <rpa-name>
+  namespace: <managed-tenant-namespace>
+spec:
+  applications:
+    - demo-app
+  data: <key>
+  origin: <dev-tenant-namespace>
+  pipeline:
+    pipelineRef:
+      resolver: git
+      params:
+        - name: url
+          value: "<url-to-repo>.git"
+        - name: revision
+          value: <revision>
+        - name: pathInRepo
+          value: "<path-to-your-pipeline>"
+    serviceAccountName: release-service-account
+    maxRetries: 5 <.>
+  policy: <policy>
+----
+
+<.> Overrides the default retry count for this RPA. Set it higher to allow more attempts or set it to `0` to
+disable automatic retries.
+
+IMPORTANT: `maxRetries` only has an effect on a Pipeline that {ProductName} already retries.
+
+== Retries can adjust resources and timeouts
+
+Retrying a failed attempt with the same resources or timeouts usually produces the same failure. To give the retry
+a chance of succeeding, {ProductName} applies mitigations to the failing Pipeline or Task on each attempt:
+
+* After an `OOMKill`, the Task or Step's memory request and limit are increased by a configured multiplier, up to a
+maximum.
+* After a `PipelineRunTimeout` or `TaskRunTimeout`, the relevant timeout is increased by a configured increment, up
+to a maximum.
+
+Mitigations are managed by {ProductName} and are not user defined.
+
+== Understand what the mitigation multiplies
+
+A mitigation multiplies or increments whatever resources or timeout the failed attempt ran with, not the Catalog's
+default. If you've overridden a Task or Step's `computeResources` using `taskRunSpecs` (See
+xref:adjusting-timeouts-resources.adoc[Adjusting timeouts and resources]), that override is the starting point for
+the next retry's mitigation. The same applies to timeouts you've set on the Pipeline.
+
+IMPORTANT: Mitigations accumulate. Each retry builds on the *previous* attempt's not the original, so
+resources or timeouts keep growing until the Release succeeds or the configured maximum is reached.
+
+== Tags that disable retries
+
+A Pipeline configured for retries can also skip retries when specific tags appear in the Release data, for example
+a `{{ incrementer }}` tag. When one of these tags is present retries are skipped for that release. The RPA's `status.retryInfo.reason`
+will read `disabled by tag: <tag>` when this happens.


### PR DESCRIPTION
Add new docs for managed pipeline retries.
Ticket: https://redhat.atlassian.net/browse/RELEASE-2682
Assisted-by: Gemini